### PR TITLE
Use a more generic name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![codecov.io](https://codecov.io/github/pycontw/pycontw2016/coverage.svg?branch=master)](https://codecov.io/github/pycontw/pycontw2016?branch=master)
 [![travis-ci status](https://api.travis-ci.org/pycontw/pycontw2016.svg?branch-master)](https://travis-ci.org/pycontw/pycontw2016)
 
-# PyCon TW 2016
+# PyCon TW
 
-This repository serves the website of PyCon TW 2016. This project is open source and the license can be found in LICENSE.
+This repository serves the website of PyCon TW, Python Conference Taiwan. This project is open source and the license can be found in LICENSE.
 
 ## Getting Started
 


### PR DESCRIPTION
We have used this repository for 2017 and 2018 as well. The code base has changed a lot when time goes by. I suggest to change the name to be more generic. Even more, we may consider to change the repository name as well.