### PR TITLE
Add Dockerfile for the 2016 Website

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM python:3.5
+
+ENV PYTHONUNBUFFERED 1
+ENV BASE_DIR /usr/local
+ENV APP_DIR $BASE_DIR/app
+ENV VENV_DIR $BASE_DIR/venv
+
+RUN apt-get update \
+ && apt-get install -y wait-for-it \
+ && adduser --system --disabled-login docker \
+ && mkdir -p "$BASE_DIR" "$APP_DIR" "$APP_DIR/src/assets" "$APP_DIR/src/media" "$VENV_DIR" \
+ && chown -R docker:nogroup "$BASE_DIR" "$APP_DIR" "$VENV_DIR"
+
+USER docker
+
+# Only copy and install requirements to improve caching between builds
+COPY --chown=docker:nogroup ./requirements $APP_DIR/requirements
+RUN python3 -m venv $VENV_DIR \
+ && "$VENV_DIR/bin/pip3" install -r "$APP_DIR/requirements/production.txt" \
+ && "$VENV_DIR/bin/python3" -m compileall \
+ && "$VENV_DIR/bin/python3" -m compileall "$VENV_DIR/lib"
+
+# Enable the virtual environment manually
+ENV VIRTUAL_ENV "$VENV_DIR"
+ENV PATH "$VENV_DIR/bin:$PATH"
+
+# Pre-compile .py files in project to improve start-up speed
+COPY --chown=docker:nogroup ./src $APP_DIR/src
+RUN "$VENV_DIR/bin/python3" -m compileall "$APP_DIR/src"
+
+# Finally, copy all the project files
+COPY --chown=docker:nogroup . $APP_DIR
+
+WORKDIR $APP_DIR/src
+VOLUME $APP_DIR/src/media
+EXPOSE 8000
+CMD ["uwsgi", "--http-socket", ":8000", "--master", "--hook-master-start", \
+     "unix_signal:15 gracefully_kill_them_all", "--static-map", \
+     "/static=assets", "--static-map", "/media=media", "--mount", \
+     "/2016=pycontw2016/wsgi.py", "--manage-script-name", "--offload-threads", \
+     "2"]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,6 +27,9 @@ django-extensions==1.6.1
 # https://github.com/torchbox/django-libsass
 django-libsass==0.6
 
+# Pin libsass's version to get aways with the '@return can only be used in function' error
+libsass==0.12.3
+
 # Translates Django models using a registration approach.
 # https://github.com/deschler/django-modeltranslation
 django-modeltranslation==0.11

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,9 +4,9 @@
 # http://pythonhosted.org/psycopg2/
 psycopg2==2.6.1
 
-# Gunicorn 'Green Unicorn' is a Python WSGI HTTP Server for UNIX.
-# http://gunicorn.org/
-gunicorn==19.4.1
+# uWSGI aims at developing a full stack for building hosting services
+# https://uwsgi-docs.readthedocs.io/
+uWSGI==2.0.17.1
 
 # django-redis is a BSD Licensed, full featured Redis cache/session backend for Django.
 # http://niwinz.github.io/django-redis/latest/

--- a/src/pycontw2016/settings/production.py
+++ b/src/pycontw2016/settings/production.py
@@ -27,7 +27,7 @@ loaders = [
 
 TEMPLATES[0]['OPTIONS'].update({"loaders": loaders})
 TEMPLATES[0]['OPTIONS'].update({"debug": False})
-del TEMPLATES[0]['APP_DIRS']
+TEMPLATES[0].pop('APP_DIRS', None)
 
 # Explicitly tell Django where to find translations.
 LOCALE_PATHS = [join(BASE_DIR, 'locale')]


### PR DESCRIPTION
This pull request adds Dockerfile that can be used to generate container image for the deployment of the 2016 website.

uWSGI is used instead of Gunicorn because uWSGI can serve static and media files without external dependencies, which provides better encapsulation IMHO; since Gunicorn will require **additional service/program that known where static and media files are located**.

Additionally, various modifications are made (specifically pinning libsass version, update `pycontw2016/settings/production.py`) in order for the application to start normally (there might be better way to get around these, I'm open to comments).