### PR TITLE
Fix typo in requirements/base.txt on the 2016 branch

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ django-extensions==1.6.1
 # https://github.com/torchbox/django-libsass
 django-libsass==0.6
 
-# Pin libsass's version to get aways with the '@return can only be used in function' error
+# Pin libsass's version to get away with the '@return can only be used in function' error
 libsass==0.12.3
 
 # Translates Django models using a registration approach.


### PR DESCRIPTION
This pull request fixes typo pointed out in https://github.com/pycontw/pycon.tw/pull/505#discussion_r265896869

