### PR TITLE
Add Dockerfile for the 2017 Website

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM python:3.6
+
+ENV PYTHONUNBUFFERED 1
+ENV BASE_DIR /usr/local
+ENV APP_DIR $BASE_DIR/app
+ENV VENV_DIR $BASE_DIR/venv
+
+RUN apt-get update \
+ && apt-get install -y wait-for-it \
+ && adduser --system --disabled-login docker \
+ && mkdir -p "$BASE_DIR" "$APP_DIR" "$APP_DIR/src/assets" "$APP_DIR/src/media" "$VENV_DIR" \
+ && chown -R docker:nogroup "$BASE_DIR" "$APP_DIR" "$VENV_DIR"
+
+USER docker
+
+# Only copy and install requirements to improve caching between builds
+COPY --chown=docker:nogroup ./requirements $APP_DIR/requirements
+RUN python3 -m venv $VENV_DIR \
+ && "$VENV_DIR/bin/pip3" install -r "$APP_DIR/requirements/production.txt" \
+ && "$VENV_DIR/bin/python3" -m compileall \
+ && "$VENV_DIR/bin/python3" -m compileall "$VENV_DIR/lib" -x 'dbfpy/dbfnew\.py'
+
+# Enable the virtual environment manually
+ENV VIRTUAL_ENV "$VENV_DIR"
+ENV PATH "$VENV_DIR/bin:$PATH"
+
+# Pre-compile .py files in project to improve start-up speed
+COPY --chown=docker:nogroup ./src $APP_DIR/src
+RUN "$VENV_DIR/bin/python3" -m compileall "$APP_DIR/src"
+
+# Finally, copy all the project files
+COPY --chown=docker:nogroup . $APP_DIR
+
+WORKDIR $APP_DIR/src
+VOLUME $APP_DIR/src/media
+EXPOSE 8000
+CMD ["uwsgi", "--http-socket", ":8000", "--master", "--hook-master-start", \
+     "unix_signal:15 gracefully_kill_them_all", "--static-map", \
+     "/static=assets", "--static-map", "/media=media", "--mount", \
+     "/2017=pycontw2016/wsgi.py", "--manage-script-name", "--offload-threads", \
+     "2"]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,6 +32,9 @@ django-extensions==1.7.8
 # https://github.com/torchbox/django-libsass
 django-libsass==0.6
 
+# Pin libsass's version to get away with the '@return can only be used in function' error
+libsass==0.12.3
+
 # Translates Django models using a registration approach.
 # https://github.com/deschler/django-modeltranslation
 django-modeltranslation==0.12

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,9 +4,9 @@
 # http://pythonhosted.org/psycopg2/
 psycopg2==2.6.1
 
-# Gunicorn 'Green Unicorn' is a Python WSGI HTTP Server for UNIX.
-# http://gunicorn.org/
-gunicorn==19.4.1
+# uWSGI aims at developing a full stack for building hosting services
+# https://uwsgi-docs.readthedocs.io/
+uWSGI==2.0.17.1
 
 # django-redis is a BSD Licensed, full featured Redis cache/session backend for Django.
 # http://niwinz.github.io/django-redis/latest/


### PR DESCRIPTION
This pull request adds Dockerfile that can be used to generate container image for the deployment of the 2017 website, similar to [the pull request for the 2016 website #505](https://github.com/pycontw/pycon.tw/pull/505).

A few differences from the Dockerfile for the 2016 website:
* Use Python 3.6
* Ignore 'dbfpy/dbfnew\.py' in the `compileall` step since that file is written in Python 2 syntax, and cause `compileall` to fail