### PR TITLE
Add Dockerfile and Deployment instructions

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,93 @@
+# Setup the Production Server
+
+The following describes how to run the server in production using Docker.
+
+It assumes that:
+
+1. A database has already been properly setup
+2. A reverse proxy is configured to forward requests to the server
+(strictly speaking the server will work without a reverse proxy, but performance
+will be awful)
+
+How to fulfill the above prerequisite is beyond the scope of this document.
+
+
+## Requirements
+
+- Git 1.8+
+- Docker 17.09+ (since we use `--chown` flag in the COPY directive)
+
+
+## Build the Container Image
+
+After cloning this repository, and checking-out the correct branch, `cd` into
+the directory and run
+
+    docker build -f Dockerfile -t pycontw-2019 .
+
+
+## Gather Container Environment Variables
+
+There are four configurations that must be set when running the container.
+
+ * `SECRET_KEY` is used to provide cryptographic signing, refer to
+   src/pycontw2016/settings/local.sample.env on how to generate secret key
+ * `DATABASE_URL` specifies how to connect to the database (in the URL form
+   e.g. `postgres://username:password@host_or_ip:5432/database_name`)
+ * `EMAIL_URL` specifies how to connect to the mail server
+   (e.g. `smtp+tls://username:password@host_or_ip:25`)
+ * `DSN_URL` specify how to connect to Sentry error reporting service
+   (e.g. `https://key@sentry.io/project`), please refer to
+   [Sentry's documentation on how to obtain Data Source Name](https://docs.sentry.io/error-reporting/quickstart/?platform=python)
+ * (optional) `GA_TRACK_ID` specify the Google Analytics ID for the website
+ * (optional) `GTM_TRACK_ID` specify the Google Google Tag Manager ID for the
+   website
+ * (optional) `SLACK_WEBHOOK_URL`
+
+For demonstration purpose, we'll use dummy values for the above container
+environment variables from here on, **please change them to according to your environment**.
+
+
+## Get Ready for Production
+
+Migrate the database to the latest schema
+
+    docker run --rm \
+      -e DJANGO_SETTINGS_MODULE='pycontw2016.settings.production.pycontw2019' \
+      -e SECRET_KEY='not_really_a_secret' \
+      -e DATABASE_URL='postgres://username:password@host_or_ip:5432/database_name' \
+      -e EMAIL_URL='smtp+tls://username:password@host_or_ip:25' \
+      -e DSN_URL='https://key@sentry.io/project' \
+      pycontw-2019 \
+      python3 manage.py migrate
+
+Generate the static assets (e.g. javascript, CSS)
+
+    docker run --rm \
+      -e DJANGO_SETTINGS_MODULE='pycontw2016.settings.production.pycontw2019' \
+      -e SECRET_KEY='not_really_a_secret' \
+      -e DATABASE_URL='postgres://username:password@host_or_ip:5432/database_name' \
+      -e EMAIL_URL='smtp+tls://username:password@host_or_ip:25' \
+      -e DSN_URL='https://key@sentry.io/project' \
+      --mount type=volume,src=pycontw-2019-static,dst=/usr/local/app/src/assets \
+      pycontw-2019 \
+      python3 manage.py collectstatic --no-input
+
+
+# Run the Production Server
+
+Run the production server container with automatic restart across failures and reboots
+
+    docker run \
+      --name=pycontw-2019 \
+      --detach \
+      --restart=always \
+      -e DJANGO_SETTINGS_MODULE='pycontw2016.settings.production.pycontw2019' \
+      -e SECRET_KEY='not_really_a_secret' \
+      -e DATABASE_URL='postgres://username:password@host_or_ip:5432/database_name' \
+      -e EMAIL_URL='smtp+tls://username:password@host_or_ip:25' \
+      -e DSN_URL='https://key@sentry.io/project' \
+      --mount type=volume,src=pycontw-2019-media,dst=/usr/local/app/src/media \
+      --mount type=volume,src=pycontw-2019-static,dst=/usr/local/app/src/assets \
+      pycontw-2019
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM python:3.6
+
+# NodeJS's version is not pinned becuase nodesource only serve the latest
+# version.
+ENV YARN_VERSION 1.15.2-1
+ENV PYTHONUNBUFFERED 1
+ENV BASE_DIR /usr/local
+ENV APP_DIR $BASE_DIR/app
+
+# Install Node and Yarn from upstream
+RUN curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+ && echo 'deb http://deb.nodesource.com/node_8.x stretch main' | tee /etc/apt/sources.list.d/nodesource.list \
+ && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+ && echo 'deb http://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list \
+ && apt-get update \
+ && apt-get install -y nodejs yarn=$YARN_VERSION \
+ && rm -rf /var/lib/apt/lists/*
+RUN adduser --system --disabled-login docker \
+ && mkdir -p "$BASE_DIR" "$APP_DIR" "$APP_DIR/src/assets" "$APP_DIR/src/media" \
+ && chown -R docker:nogroup "$BASE_DIR" "$APP_DIR"
+
+USER docker
+WORKDIR $APP_DIR
+# Add bin directory used by `pip install --user`
+ENV PATH "/home/docker/.local/bin:${PATH}"
+
+# Only copy and install requirements to improve caching between builds
+# Install Python dependencies
+COPY --chown=docker:nogroup ./requirements $APP_DIR/requirements
+RUN pip3 install --user -r "$APP_DIR/requirements/production.txt" \
+ && rm -rf $HOME/.cache/pip/*
+# Install Javascript dependencies
+COPY --chown=docker:nogroup ./package.json $APP_DIR/package.json
+COPY --chown=docker:nogroup ./yarn.lock $APP_DIR/yarn.lock
+RUN yarn install --dev --frozen-lockfile \
+ && rm -rf $HOME/.cache/yarn/*
+# Finally, copy all the project files along with source files
+COPY --chown=docker:nogroup . $APP_DIR
+
+WORKDIR $APP_DIR/src
+VOLUME $APP_DIR/src/media
+EXPOSE 8000
+CMD ["uwsgi", "--http-socket", ":8000", "--master", \
+     "--hook-master-start", "unix_signal:15 gracefully_kill_them_all", \
+     "--static-map", "/static=assets", "--static-map", "/media=media", \
+     "--mount", "/2019=pycontw2016/wsgi.py", "--manage-script-name", \
+     "--offload-threads", "2"]

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,4 +1,9 @@
 -r base.txt
+# A pickled object field for Django. (Dependency of django-q)
+# https://github.com/gintas/django-picklefield
+# Pin to version 1.0.0, the last version that supports Django < 1.11
+django-picklefield==1.0.0
+
 # Psycopg is the most popular PostgreSQL database adapter for the Python
 # programming language.
 # http://pythonhosted.org/psycopg2/

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,9 +4,9 @@
 # http://pythonhosted.org/psycopg2/
 psycopg2==2.7.3.2
 
-# Gunicorn 'Green Unicorn' is a Python WSGI HTTP Server for UNIX.
-# http://gunicorn.org/
-gunicorn==19.7.1
+# uWSGI aims at developing a full stack for building hosting services
+# https://uwsgi-docs.readthedocs.io/
+uWSGI==2.0.17.1
 
 # django-redis is a BSD Licensed, full featured Redis cache/session backend for Django.
 # http://niwinz.github.io/django-redis/latest/


### PR DESCRIPTION
The pull request adds `Dockerfile` for creating container image (similar to [the pull request for 2018 website #542](https://github.com/pycontw/pycon.tw/pull/542)) as well as instruction on how to deploy the website to production in `DEPLOY.md`.

Again, `django-picklefield` is pinned to version 1.0.0 since later version no longer supports Django 1.10, which is used for the 2018 website.