### PR TITLE
Fix redundant typo of open space introduction

### DIFF
--- a/src/templates/pycontw-2019/contents/zh/events/open-spaces.html
+++ b/src/templates/pycontw-2019/contents/zh/events/open-spaces.html
@@ -56,8 +56,6 @@
 	<li>求職相關討論</li>
 </ul>
 
-您也可以參考看看 [PyCon US 2018 的 Open Spaces 活動](https://us.pycon.org/2018/events/open-spaces) ，有許多很棒的開放空間的主題可以參考！
-
 <p>您也可以參考看看 <a href="https://us.pycon.org/2018/events/open-spaces" target="_blank" rel="noopener">PyCon US 2018 的 Open Spaces 活動</a>，有許多很棒的開放空間的主題可以參考！</p>
 
 {% endblock content %}


### PR DESCRIPTION
There is an extra line of this page https://tw.pycon.org/2019/zh-hant/events/open-spaces/