### PR TITLE
Update Dockerfile to fetch expected nodejs version

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -31,6 +31,35 @@ There are four configurations that must be set when running the container.
 Write them in a [`.env` file](https://docs.docker.com/compose/env-file/) at the same directory that contains
 `docker-compose.yml`.
 
+## Deploying Associated Services
+
+To deploy the website, we also need the following two service (at least):
+
+  * [Nginx service for PyCon Taiwan website](https://github.com/pycontw/pycontw-nginx)
+  * [PostgreSQL service for PyCon Taiwan website](https://github.com/pycontw/pycontw-postgresql)
+
+Firstly, fetch the `docker-compose.yaml` files from the above links of the Nginx and PostgreSQL service respectively, and then deploy the PostgresSQL service by
+
+```
+# cd pycontw-postgresql
+docker-compose up --build -d
+```
+
+and then deploy the Nginx service by
+
+```
+# cd pycontw-nginx
+docker-compose up --build -d
+```
+
+If your docker processes are up correctly by checking `docker container ls`, you are ready to deploy the website like
+
+```
+docker-compose stop ; docker-compose rm -f ; docker-compose pull ; docker-compose up --build -d
+```
+
+You may skip the part of `docker-compose stop`, `docker-compose rm -f`, and `docker-compose pull` if you are build from scratch so there is no pre-existing pycontw website containers.
+
 # Run the Production Server
 
 Run the production server container:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,19 +9,21 @@ ENV NVM_DIR $BASE_DIR/nvm
 ENV YARN_VERSION 1.15.2-1
 ENV NODE_VERSION 8.16.0
 
+# make nodejs and yarn accessible and executable globally
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+# Add bin directory used by `pip install --user`
+ENV PATH "/home/docker/.local/bin:${PATH}"
+
 # Install Node and Yarn from upstream
 RUN curl -o- $NVM_INSTALLER_URL | bash \
  && . $NVM_DIR/nvm.sh \
  && nvm install $NODE_VERSION \
  && nvm alias default $NODE_VERSION \
  && nvm use default \
- && nvm --version
-RUN . $NVM_DIR/nvm.sh \
+ && nvm --version \
  && npm install -g yarn \
- && yarn --version \
-# make nodejs and yarn accessible and executable globally
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+ && yarn --version
 
 # APP directory setup
 RUN adduser --system --disabled-login docker \
@@ -30,8 +32,6 @@ RUN adduser --system --disabled-login docker \
 
 USER docker
 WORKDIR $APP_DIR
-# Add bin directory used by `pip install --user`
-ENV PATH "/home/docker/.local/bin:${PATH}"
 
 # Only copy and install requirements to improve caching between builds
 # Install Python dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.6
 # NodeJS's version is not pinned becuase nodesource only serve the latest
 # version.
 ENV YARN_VERSION 1.15.2-1
+ENV NODEJS_VERSION 8.16.0-1nodesource1
 ENV PYTHONUNBUFFERED 1
 ENV BASE_DIR /usr/local
 ENV APP_DIR $BASE_DIR/app
@@ -13,7 +14,7 @@ RUN curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add 
  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
  && echo 'deb http://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list \
  && apt-get update \
- && apt-get install -y nodejs yarn=$YARN_VERSION \
+ && apt-get install -y nodejs=$NODEJS_VERSION yarn=$YARN_VERSION \
  && rm -rf /var/lib/apt/lists/*
 RUN adduser --system --disabled-login docker \
  && mkdir -p "$BASE_DIR" "$APP_DIR" "$APP_DIR/src/assets" "$APP_DIR/src/media" \


### PR DESCRIPTION
The current deb buster repository provides 10.x nodejs[1] and will override the expected nodejs version (8.x) to make the deployment fail. This pull request fixes the expected nodejs and tested with a clone pycontw 2019 website served with a postgresql and nginx service. 



[1]

```
nodejs:
  Installed: (none)
  Candidate: 10.15.2~dfsg-2
  Version table:
     10.15.2~dfsg-2 500
        500 http://deb.debian.org/debian buster/main amd64 Packages
     8.16.0-1nodesource1 500
        500 http://deb.nodesource.com/node_8.x stretch/main amd64 Packages
```