### PR TITLE
feat: 🎸 add ccip staff and sponsor page

### DIFF
--- a/src/templates/pycontw-2019/_includes/staff.html
+++ b/src/templates/pycontw-2019/_includes/staff.html
@@ -2,129 +2,133 @@
 
 <h2>{% trans 'Chairperson' context 'staff' %}</h2>
 <ul class="staff-list">
-	<li>Tzu-ping Chung</li>
+	<li>tai271828</li>
 </ul>
 
 <h2>{% trans 'Registration' context 'staff' %}</h2>
 <ul class="staff-list">
-	<li>胡崇偉 marr</li>
-	<li>蔡育承 Yucheng</li>
-	<li>朱幸一 Hsinge</li>
-	<li>陳炯廷 Tom</li>
+	<li>Marr</li>
+	<li>Yucheng</li>
+	<li>弘哲</li>
+	<li>Tom Chen</li>
+	<li>Skye</li>
+	<li>Tumi</li>
 </ul>
-
 <h2>{% trans 'Development' context 'staff' %}</h2>
 <ul class="staff-list">
-	<li>Keith</li>
 	<li>James</li>
-	<li>Denny</li>
-	<li>IU</li>
+	<li>GTB</li>
+	<li>Wilson</li>
+	<li>舜喜</li>
+	<li>Herber</li>
+	<li>Frank Lin</li>
+	<li>Weida</li>
+	<li>Henry</li>
+	<li>David</li>
+	<li>Alice</li>
+</ul>
+<h2>{% trans 'OPass Development' context 'staff' %}</h2>
+<ul class="staff-list">
+	<li>Denny Huang</li>
 	<li>腹黒い茶</li>
+	<li>Frank Wu</li>
+	<li>大倫</li>
+	<li>Jack</li>
 </ul>
 
 <h2>{% trans 'Public Relations' context 'staff' %}</h2>
 <ul class="staff-list">
-	<li>Zonghan</li>
+	<li>Hane</li>
+	<li>宗翰</li>
 	<li>Mike</li>
-	<li>慈恩</li>
 	<li>阿哲</li>
-	<li>Yen-Hsuan Chu</li>
+	<li>米方</li>
+	<li>Jenny</li>
+	<li>冠廷</li>
 </ul>
 
 <h2>{% trans 'Design' context 'staff' %}</h2>
 <ul class="staff-list">
+	<li>Kaya</li>
 	<li>蔡帛軒</li>
-	<li>Elaine</li>
-	<li>YuHsiang Wang</li>
+	<li>卡卡</li>
+	<li>蔡帛軒</li>
+	<li>琪琪</li>
+	<li>禹翔</li>
+	<li>柔安</li>
+	<li>Alice</li>
+	<li>Andy</li>
+	<li>Carol Cho</li>
 </ul>
 
 <h2>{% trans 'Photography' context 'staff' %}</h2>
 <ul class="staff-list">
+	<li>Andy</li>
 	<li>Deimos</li>
-	<li>阿賢</li>
-	<li>Irene</li>
-	<li>明洋</li>
-	<li>Charles</li>
-	<li>友豪</li>
-	<li>彥蓁</li>
-	<li>三子</li>
-	<li>家維</li>
+	<li>吳秉玹</li>
+	<li>小草</li>
+	<li>Jason</li>
+	<li>黃家賢</li>
+	<li>林筠庭</li>
+	<li>Jim</li>
+	<li>Vincent</li>
+	<li>HY</li>
+	<li>Kaminyou</li>
+	<li>YiShan</li>
 </ul>
 
 <h2>{% trans 'Program' context 'staff' %}</h2>
 <ul class="staff-list">
-	<li>廖偉涵 Adrian Liaw</li>
-	<li>陳一傑 Yi-Chieh Chen</li>
-	<li>蔡智晴 Candy Tsai</li>
-	<li>李昂 Leon Xue</li>
-	<li>林育德 Yu-De Lin</li>
-	<li>陳威祐 Wei-Yu Chen</li>
-	<li>呂紹榕 Louie Lu</li>
+	<li>Adrian</li>
+	<li>TP</li>
+	<li>Jason</li>
+	<li>Wei Lee</li>
+	<li>Kevin</li>
+	<li>鯉魚</li>
+	<li>Ellie</li>
+	<li>KK</li>
+	<li>宗翰</li>
+	<li>Eric</li>
+	<li>Victor</li>
+	<li>Chris</li>
 </ul>
 
 <h2>{% trans 'Sponsorship' context 'staff' %}</h2>
 <ul class="staff-list">
-	<li>泰祥</li>
-	<li>Hubert</li>
-	<li>士豪</li>
-	<li>家誠</li>
-	<li>祐豪</li>
-	<li>筠樺</li>
-	<li>蕭辰翰 Stanley</li>
-	<li>廖利豪 Leon</li>
-	<li>賈媛 Stephanie</li>
-	<li>映辰</li>
-	<li>Liting</li>
+	<li>Robert Lin</li>
+	<li>Yun Hua Hsiao</li>
+	<li>Rain Wu</li>
+	<li>Bill Wang</li>
+	<li>Elliott Lin</li>
+	<li>Andy</li>
+	<li>黃坤賢</li>
+	<li>Liting Chen</li>
+	<li>祐豪五六</li>
+	<li>Eric Xie</li>
 </ul>
 
 <h2>{% trans 'Financial' context 'staff' %}</h2>
 <ul class="staff-list">
 	<li>Rock</li>
+	<li>Eric Xie</li>
 </ul>
 
 <h2>{% trans 'Venue' context 'staff' %}</h2>
 <ul class="staff-list">
-	<li>Tim Hsu</li>
-	<li>融易</li>
-	<li>Larry Guo</li>
-	<li>管軒晧 (小管)</li>
-	<li>可微</li>
-	<li>Oxy</li>
-	<li>Singing</li>
-	<li>皇甫</li>
-	<li>Jack Cheng</li>
+	<li>Tim</li>
+	<li>Rex Wu</li>
+	<li>David Lu</li>
+	<li>Eren</li>
+</ul>
+
+<h2>{% trans 'Maneuvering' context 'staff' %}</h2>
+<ul class="staff-list">
+	<li>Angela</li>
+	<li>Wei Lee</li>
+	<li>鯉魚</li>
 </ul>
 
 <h2>{% trans 'Review Committee' context 'staff' %}</h2>
 <ul class="staff-list">
-	<li>Kir Chou</li>
-	<li>廖偉涵 Adrian Liaw</li>
-	<li>李昱勳 Andy Lee</li>
-	<li>Ping Chu Hung</li>
-	<li>Candy Tsai</li>
-	<li>Yi-Chieh Chen</li>
-	<li>梁智程</li>
-	<li>宋政隆 Cheng-Lung Sung</li>
-	<li>Andy Dai</li>
-	<li>Shuen-Huei Guan</li>
-	<li>曾君宇 Chun-Yu Tseng</li>
-	<li>郭學聰 Hsueh-Tsung Kuo</li>
-	<li>Michelle Leu</li>
-	<li>Yi Hsiao</li>
-	<li>Zong-han Xie</li>
-	<li>Jian-Ming Huang</li>
-	<li>Kuo-tung Kao</li>
-	<li>TsungWei Hu</li>
-	<li>Spin Lai</li>
-	<li>Rex Tsai</li>
-	<li>Tim Hsu</li>
-	<li>柯維然 Odie</li>
-	<li>Tzu-ping Chung</li>
-	<li>Wei Lin</li>
-	<li>Stanley Huang</li>
-	<li>Star Willy</li>
-	<li>Keith Yang</li>
-	<li>趙元 Yuan Chao</li>
-	<li>Jimmy Lai</li>
-	<li>Yung-Yu Chen</li>
+	<li>To be continued</li>
 </ul>

--- a/src/templates/pycontw-2019/ccip/sponsors.html
+++ b/src/templates/pycontw-2019/ccip/sponsors.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+
+{% load i18n static %}
+
+{% block styles %}
+<link rel="stylesheet" type="text/x-scss" href="{% static 'pycontw-2019/styles/ccip.scss' %}">
+{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono:100i">
+{% endblock extra_css %}
+
+{% block titletag %}
+<title>PyCon Taiwan 2019</title>
+{% endblock titletag %}
+
+{% block nav %}{% endblock nav %}
+
+{% block content_full %}
+{% language 'en-us' %}
+{% include '_includes/sponsors.html' %}
+{% endlanguage %}
+{% endblock content_full %}
+
+{% block footer %}
+<footer></footer>
+{% endblock footer %}

--- a/src/templates/pycontw-2019/ccip/staff.html
+++ b/src/templates/pycontw-2019/ccip/staff.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block styles %}
+{{ block.super }}
+<link rel="stylesheet" type="text/x-scss" href="{% static 'pycontw-2018/styles/ccip.scss' %}">
+{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono:100i">
+{% endblock extra_css %}
+
+{% block titletag %}
+<title>PyCon Taiwan 2019</title>
+{% endblock titletag %}
+
+{% block nav %}{% endblock nav %}
+
+{% block content_full %}
+{% include '_includes/staff.html' %}
+{% endblock content_full %}
+
+{% block footer %}
+<footer></footer>
+{% endblock footer %}
+
+


### PR DESCRIPTION
新增ccip 的sponsor和staff page
staff page:
新增機動跟OPass開發兩組，機動我翻成Maneuvering不知道是不是最適合
另外這兩個翻譯可能要請人去補一下
審稿委員還在等