### PR TITLE
fix: 🐛 add staff href back in footer html

### DIFF
--- a/src/templates/pycontw-2019/_includes/footer.html
+++ b/src/templates/pycontw-2019/_includes/footer.html
@@ -10,7 +10,7 @@
 	</div>
 	<ul>
 		<li><a href="{{ coc_url }}">{% trans 'Code of Conduct' %}</a></li>
-		{# <li><a href="{{ staff_url }}">{% trans 'Staff' %}</a></li> #}
+		<li><a href="{{ staff_url }}">{% trans 'Staff' %}</a></li>
 		<li><a href="{{ community_url }}">{% trans 'Community' %}</a></li>
 	</ul>
 	<p class="copyright">2019 PyCon Taiwan</p>


### PR DESCRIPTION
將原本註解掉的staff頁面補回來
![image](https://user-images.githubusercontent.com/14121801/65313294-b77de700-dbc6-11e9-8827-f7a5026688f4.png)

![image](https://user-images.githubusercontent.com/14121801/65313425-e85e1c00-dbc6-11e9-9e98-4dfd574f1a03.png)
