### PR TITLE
feat: add 2020 cfp, about, event content (en)

### DIFF
--- a/src/templates/pycontw-2020/contents/en/about/code-of-conduct.html
+++ b/src/templates/pycontw-2020/contents/en/about/code-of-conduct.html
@@ -1,0 +1,24 @@
+{% extends 'contents/_base.html' %}
+
+{% block title %}行為準則{% endblock title %}
+
+{% block content %}
+
+<h1>Code of Conduct</h1>
+
+<p>PyCon Taiwan is a community-driven convention for the Python programming language in Taiwan, created to facilitate discussions and exchange of ideas in the community. To provide a joyful, pleasant, and vibrant environment that creates value for all participants, we hereby publish PyCon Taiwan’s Code of Conduct, which applies to all speech and action in both physical and digital venues of PyCon Taiwan. Your cooperation is necessary to help all of us to interact with respect and trust in PyCon Taiwan.</p>
+
+
+<h2>Code of Conduct</h2>
+
+<p>Do not harass others, either verbally, physically, or otherwise. Harassment and discrimination is given zero tolerance. Each attendee should be equally respected regardless of nationality, race, language, gender, sexual orientation, age, disability, physical appearance, faith, profession, seniority, political view, or intellect.</p>
+
+<p>Appreciate each other. Each attendee is expected to show a professional attitude, and behave accordingly. User of Python are diverse in their professional roles, technical backgrounds, and application areas. They contribute to the technology in many different ways, some amazingly unimaginable. Opinions or actions that undervalue other members of the community are inappropriate.</p>
+
+<p>Show consideration to others. Sexual contents in any form are inappropriate in any conference venues, including but not limited to talks, open spaces, or social media. Words and actions originated from stereotypes are discouraged. Cell phones should be set to silence or a mode that does not annoy others in the conference rooms.</p>
+
+<p>The conference organizers have the power to take appropriate actions to redirect behavior of those who violate the Code of Conduct. Violators may be forced to leave the conference without a refund at the sole discretion of the organizers.</p>
+
+<p>This Code of Conduct is approved by the organizers of PyCon Taiwan.</p>
+
+{% endblock content %}

--- a/src/templates/pycontw-2020/contents/en/about/code-of-conduct.html
+++ b/src/templates/pycontw-2020/contents/en/about/code-of-conduct.html
@@ -1,6 +1,6 @@
 {% extends 'contents/_base.html' %}
 
-{% block title %}行為準則{% endblock title %}
+{% block title %}Code of Conduct{% endblock title %}
 
 {% block content %}
 

--- a/src/templates/pycontw-2020/contents/en/event/open-spaces.html
+++ b/src/templates/pycontw-2020/contents/en/event/open-spaces.html
@@ -15,7 +15,7 @@
 
 <p>It’s pretty easy: Just show up :)</p>
 
-<p>During the Conference, there will be several tables in the Multifunction (1F). The tables act as an Open Space. There will be a board on each table as its topic. You can find your interested topic and use the memo to write down your thoughts and feedbacks. If a topic is not listed yet, just write down what you would like to talk about on a non-topic board!</p>
+<p>During the Conference, there will be several tables in the Multifunction Room(1F). The tables act as an Open Space. There will be a board on each table as its topic. You can find your interested topic and use the memo to write down your thoughts and feedbacks. If a topic is not listed yet, just write down what you would like to talk about on a non-topic board!</p>
 
 
 <h2>What Open Spaces are there?</h2>
@@ -27,12 +27,12 @@
 
 <h2>Where and when are the Open Spaces?</h2>
 
-<p>The Open Staces happen in parallel with the main conference, which are held at the Multifunction (1F). Feel free to enjoy the exciting discussions of the Open Spaces.</p>
+<p>The Open Staces happen in parallel with the main conference, which are held at the Multifunction Room(1F). Feel free to enjoy the exciting discussions of the Open Spaces.</p>
 
 
 <h2>How do I host an Open Space?</h2>
 
-<p>During the conference, there are several tables at the multifunction room(1F). There will be a board on each table. All you need is to write down your name and the topic abstract，and show up on the Open Spaces time slot. It’s also good to add your contact information such as Twitter handle, Gitter/GitHub ID, Telegram ID, etc. to the note in case anyone interested in attending your Open Space has a question or would like to contact you about it.</p>
+<p>During the conference, there are several tables at the Multifunction Room(1F). There will be a board on each table. All you need is to write down your name and the topic abstract, and show up on the Open Spaces time slot. It’s also good to add your contact information such as Twitter handle, Gitter/GitHub ID, Telegram ID, etc. to the note in case anyone interested in attending your Open Space has a question or would like to contact you about it.</p>
 
 
 <h2>Ideas for Open Spaces</h2>

--- a/src/templates/pycontw-2020/contents/en/event/open-spaces.html
+++ b/src/templates/pycontw-2020/contents/en/event/open-spaces.html
@@ -46,7 +46,7 @@
 	<li>Natural language processing and generation (e.g. chatbots)</li>
 	<li>Quantified self</li>
 	<li>Diversity initiatives, for example a feminist hackerspace</li>
-	<li>A space for organizers of conferences, workshops, local meetups </li>
+	<li>A space for organizers of conferences, workshops, local communities </li>
 	<li>Framework-specific Open Spaces, e.g. Django or Flask</li>
 	<li>How to contribute to open source, a help / mentoring group for beginners</li>
 	<li>Git</li>

--- a/src/templates/pycontw-2020/contents/en/event/open-spaces.html
+++ b/src/templates/pycontw-2020/contents/en/event/open-spaces.html
@@ -1,0 +1,59 @@
+{% extends 'contents/_base.html' %}
+
+{% block title %}Open Spaces{% endblock %}
+
+{% block content %}
+
+<h1>Open Spaces</h1>
+
+<p>Open Spaces are self-organizing meetup-like events which happen in parallel with the main conference. They are held in Multifunction Room(1F) of the conference venue.  While most of the conference is planned months in advance, Open Spaces are created “just in time” by PyCon attendees during the conference. They provide a way for you to self-gather, self-define, and self-organize any way you like.</p>
+
+<p>For those who have participated previous PyCon Taiwan conferences, Open Spaces may sound familiar to you, and yes it’s basically a friendlier term for <a href="https://tw.pycon.org/2014apac/en/bof/" target="_blank" rel="noopener">BoF (Birds of a Feather)</a>, easier to guess at a glance for new conference attendees.</p>
+
+
+<h2>How do I participate in an Open Space?</h2>
+
+<p>It’s pretty easy: Just show up :)</p>
+
+<p>During the Conference, there will be several tables in the Multifunction (1F). The tables act as an Open Space. There will be a board on each table as its topic. You can find your interested topic and use the memo to write down your thoughts and feedbacks. If a topic is not listed yet, just write down what you would like to talk about on a non-topic board!</p>
+
+
+<h2>What Open Spaces are there?</h2>
+
+<p>We don’t know either! It’s up to you and fellow attendees 😉</p>
+
+<p>There are Open Spaces on many subjects a bunch of PyCon attendees would like to discuss. Since the PyCon attendees are a diverse bunch, the Open Spaces are too. An Open Space can be a mani/pedi party, a feminist hacking space, an AcroYoga space, or even a board games room. It can also be some discussions about plenty of the usual suspects of technical subjects, from computer security to your favorite Python project to professional occupations like DevOps.</p>
+
+
+<h2>Where and when are the Open Spaces?</h2>
+
+<p>The Open Staces happen in parallel with the main conference, which are held at the Multifunction (1F). Feel free to enjoy the exciting discussions of the Open Spaces.</p>
+
+
+<h2>How do I host an Open Space?</h2>
+
+<p>During the conference, there are several tables at the multifunction room(1F). There will be a board on each table. All you need is to write down your name and the topic abstract，and show up on the Open Spaces time slot. It’s also good to add your contact information such as Twitter handle, Gitter/GitHub ID, Telegram ID, etc. to the note in case anyone interested in attending your Open Space has a question or would like to contact you about it.</p>
+
+
+<h2>Ideas for Open Spaces</h2>
+
+<p>Here are a few ideas for potential Open Space topics and activities:</p>
+
+<ul>
+	<li>Hacker space (maker projects) that use Python (e.g. in Raspbery Pis, IOT, home automation, robots / drones / blimps autopiloted with Python)</li>
+	<li>Hacking / Networking / DevOps</li>
+	<li>Data visualization / Science</li>
+	<li>Natural language processing and generation (e.g. chatbots)</li>
+	<li>Quantified self</li>
+	<li>Diversity initiatives, for example a feminist hackerspace</li>
+	<li>A space for organizers of conferences, workshops, local meetups </li>
+	<li>Framework-specific Open Spaces, e.g. Django or Flask</li>
+	<li>How to contribute to open source, a help / mentoring group for beginners</li>
+	<li>Git</li>
+	<li>Support: how to avoid burnout</li>
+	<li>Recruitment workshops</li>
+</ul>
+
+<p>Take a look at what Open Spaces are there at <a href="https://us.pycon.org/2019/events/open-spaces" target="_blank" rel="noopener">PyCon US 2019</a>. There are some great examples for Open Space topics</p>
+
+{% endblock content %}

--- a/src/templates/pycontw-2020/contents/en/speaking/cfp.html
+++ b/src/templates/pycontw-2020/contents/en/speaking/cfp.html
@@ -2,7 +2,7 @@
 
 {% block title %}Call for Proposals {% endblock title %}
 
-{% block meta_description %}The Call for Proposals is now open. PyCon 2020 Taiwan is accepting talks and tutorials!{% endblock meta_description %}
+{% block meta_description %}The Call for Proposals is now open. PyCon Taiwan 2020 is accepting talks and tutorials!{% endblock meta_description %}
 
 {% block content %}
 {% url 'page' path='speaking/recording' as speaking_recording_url %}
@@ -34,7 +34,7 @@
 
 <h2>How to Submit Your Proposal</h2>
 
-<p>You need to <a href="{{ signup_url }}">sign up</a>  a new account on tw.pycon.org. With an activated account, you can fill up the speaker profile and create new proposals through the <a href="{{ dashboard_url }}">My PyCon</a> page.</p>
+<p>You need to <a href="{{ signup_url }}">sign up</a> for a new account on tw.pycon.org. With an activated account, you can fill up the speaker profile and create new proposals through the <a href="{{ dashboard_url }}">My PyCon</a> page.</p>
 
 <p>We encourage you to submit the proposal as early as possible. You are welcomed to submit multiple proposals.</p>
 
@@ -67,7 +67,7 @@
 <h3>Tutorials</h3>
 
 <p>Similar to talks, we don’t pose limitations on tutorial topics.
-  Tutorials are paid, half or full day long, equivalent to 3 or 6 hours of teaching.
+  This year, tutorials are free and the length has been changed to 1 hour and 30 mintues.
   The guideline for tutorial submission is based on the guideline for talks,
   so make sure you have read <a href="{{ speaking_talk_url }}"> How to Propose a Talk?</a>
   On top of that, We have some special requirements for tutorial submission,

--- a/src/templates/pycontw-2020/contents/en/speaking/cfp.html
+++ b/src/templates/pycontw-2020/contents/en/speaking/cfp.html
@@ -18,7 +18,7 @@
 <p>The Call for Proposals is now open. PyCon 2020 Taiwan is accepting talks and tutorials!</p>
 
 
-<h2>Important Dates(<a href="https://en.wikipedia.org/wiki/Anywhere_on_Earth">AoE</a>)</h2>
+<h2>Important Dates(<a href="https://en.wikipedia.org/wiki/Anywhere_on_Earth">We use AoE timezone.</a>)</h2>
 
 <ul>
 	<li>Talks &amp; Tutorial CfP begins: 1 Mar </li>

--- a/src/templates/pycontw-2020/contents/en/speaking/cfp.html
+++ b/src/templates/pycontw-2020/contents/en/speaking/cfp.html
@@ -1,0 +1,98 @@
+{% extends 'contents/_base.html' %}
+
+{% block title %}Call for Proposals {% endblock title %}
+
+{% block meta_description %}The Call for Proposals is now open. PyCon 2020 Taiwan is accepting talks and tutorials!{% endblock meta_description %}
+
+{% block content %}
+{% url 'page' path='speaking/recording' as speaking_recording_url %}
+{% url 'page' path='speaking/talk' as speaking_talk_url %}
+{% url 'page' path='speaking/tutorial' as speaking_tutorial_url %}
+{% url 'page' path='event/open-space' as event_open-space_url %}
+{% url 'page' path='about/code-of-conduct' as about_coc_url %}
+{% url 'signup' as signup_url %}
+{% url 'user_dashboard' as dashboard_url %}
+
+<h1>Call for Proposals </h1>
+
+<p>The Call for Proposals is now open. PyCon 2020 Taiwan is accepting talks and tutorials!</p>
+
+
+<h2>Important Dates(<a href="https://en.wikipedia.org/wiki/Anywhere_on_Earth">AoE</a>)</h2>
+
+<ul>
+	<li>Talks &amp; Tutorial CfP begins: 1 Mar </li>
+	<li>Talks &amp; Tutorial CfP ends: 26 Apr（23:59）</li>
+  <li>Announcement of acceptance: In the middle of June (tentative)</li>
+  <li>Dates of the Conference：5 Sep - 6 Sep</li>
+</ul>
+
+<p>All talks will be recorded, edited then uploaded to <a href="http://pyvideo.org" target="_blank" rel="noopener">pyvideo.org</a> by the PyCon Taiwan committee, unless the speaker requests otherwise. See more info about the <a href="{{ speaking_recording_url }}">recording release</a>.</p>
+
+<p>All speakers are required to buy their own conference tickets（<a href="http://pyfound.blogspot.com/2017/10/psfs-october-board-meeting.html" target="_blank" rel="noopener">Everyone Contributes Policy</a>）</p>
+
+
+<h2>How to Submit Your Proposal</h2>
+
+<p>You need to <a href="{{ signup_url }}">sign up</a>  a new account on tw.pycon.org. With an activated account, you can fill up the speaker profile and create new proposals through the <a href="{{ dashboard_url }}">My PyCon</a> page.</p>
+
+<p>We encourage you to submit the proposal as early as possible. You are welcomed to submit multiple proposals.</p>
+
+
+<h2>Guidelines for Proposal Submission</h2>
+
+<h3>Talks</h3>
+
+<p>We accept a broad range of Python-related proposals, from academic research to commercial projects and case studies, or soft topics such as running a community, making good communication, mental health, etc.  Basically, if you are reading these words, you should go submit your proposal!</p>
+
+<p>We encourage speakers to talk about your own Python package or application, your experience of learning Python or hosting a Python community etc. Talks on advanced topics are highly welcomed as well. For your inspiration, our committee has suggested that they’d love to see talks on following topics: <em>FinTech, Community, A.I, Data Analytics, IoT, Machine Learning, Testing</em>, etc.</p>
+
+<p>When considering different topics, you may be interested in reviewing selected speeches over the past few years at PyCon Taiwan.</p>
+
+<ul>
+  <li><a href="https://tw.pycon.org/2019/en-us/events/schedule/">PyCon Taiwan 2019</a></li>
+  <li><a href="https://tw.pycon.org/2018/en-us/events/schedule/">PyCon Taiwan 2018</a></li>
+  <li><a href="https://tw.pycon.org/2017/en-us/events/schedule/">PyCon Taiwan 2017</a></li>
+  <li><a href="https://tw.pycon.org/2016/en-us/events/schedule/">PyCon Taiwan 2016</a></li>
+</ul>
+
+<p>Talks will be lasting either <em>30 minutes</em> or <em>15 minutes</em>, depends on you, you'll measure and decide how much time you need.  Note that the length of a talk <em>includes setup and Q&amp;A session</em>.</p>
+
+<p>Talks can be given in either <em>English, Mandarin or Taiwanese Hokkien.</em></p>
+
+<p>If it's your first time to propose a talk at PyCon Taiwan or a conference in general, please have a look at <a href="{{ speaking_talk_url }}">How to Propose a Talk?</a> to learn more about conventions, and it might help you organise your thoughts on your proposal.</p>
+
+<p>If your submissions are not selected in PyCon Taiwan, you can choose whether you want to share the talks at the local communities. PyCon Taiwan will provide partial transportation fee. </p>
+
+<h3>Tutorials</h3>
+
+<p>Similar to talks, we don’t pose limitations on tutorial topics.
+  Tutorials are paid, half or full day long, equivalent to 3 or 6 hours of teaching.
+  The guideline for tutorial submission is based on the guideline for talks,
+  so make sure you have read <a href="{{ speaking_talk_url }}"> How to Propose a Talk?</a>
+  On top of that, We have some special requirements for tutorial submission,
+  please refer to <a href="{{ speaking_tutorial_url }}">How to Propose a Tutorial?</a>
+  for more information.</p>
+
+<h2>Proposals Review Process</h2>
+
+<p>After the Call for Proposal ends, and before the announcement of acceptance, the PyCon TW 2020 Proposals Review Committee is going to review the proposals and give scores and provide useful feebacks. The process consists of three phases:</p>
+<ul>
+  <li>Stage 1 Review: Reviewers are going to score and give feedbacks. This will last for about 2 ~ 3 weeks</li>
+  <li><em>Modification Step: According to reviewers’ comments, you can modify your proposal through the dashboard.</em> This steps lasts for about 1 to 2 weeks</li>
+  <li>Stage 2 Review: Reviewers are going to re-score and re-give feedacks to the modified proposals</li>
+</ul>
+
+<h3>Modification Step</h3>
+<p>
+  Between the stage-1 and stage-2 review, you can see the feedbacks from the reviewer.
+  You may modify your proposal according to reviewers’ comments or feedbacks. If you want to make your change obvious to the reviewers, you can point out the ID of the comment, and mention about what you’ve modified according to the comment in the <em>"Supplementary"</em> section, e.g. <em>"#4: Updated the time management for xxx phase"</em>
+</p>
+
+<p>If you have any questions, please contact us at <a href="mailto:program@pycon.tw">program@pycon.tw</a>.</p>
+
+<h3>Inappropriate words or images</h3>
+
+<p>Please note that PyCon Taiwan is a conference where the audience comes from different cultural backgrounds. Some jokes may be rude to others. If you want to add some humorous images or words to your speech, please double check if there is any possibility of offense, and refer to our <a href="{{ about_coc_url }}"> Code of Conduct </a>.</p>
+
+{% endblock content %}

--- a/src/templates/pycontw-2020/contents/en/speaking/recording.html
+++ b/src/templates/pycontw-2020/contents/en/speaking/recording.html
@@ -1,0 +1,12 @@
+{% extends 'contents/_base.html' %}
+
+{% block title %}錄影釋出{% endblock title %}
+
+{% block content %}
+
+<h1>Recording Release</h1>
+
+<p>Since one of the PyCon motivation is to help Python education and advocate the use Python, by default <em>all talks are recorded</em>. If the speaker agrees to give permission to PyCon Taiwan, we will record, edit, and release the audio and video of the speaker's presentation to online video site such as Youtube and <a href="http://pyvideo.org/" target="_blank" rel="noopener">pyvideo.org</a>. The recording might be also live streamed if it is technically feasible.</p>
+
+<p>If you don’t want your talk being recorded, make sure you leave the recording option unchecked during the proposal submission.</p>
+{% endblock content %}

--- a/src/templates/pycontw-2020/contents/en/speaking/recording.html
+++ b/src/templates/pycontw-2020/contents/en/speaking/recording.html
@@ -1,6 +1,6 @@
 {% extends 'contents/_base.html' %}
 
-{% block title %}錄影釋出{% endblock title %}
+{% block title %}Recording Release{% endblock title %}
 
 {% block content %}
 

--- a/src/templates/pycontw-2020/contents/en/speaking/talk.html
+++ b/src/templates/pycontw-2020/contents/en/speaking/talk.html
@@ -1,0 +1,129 @@
+{% extends 'contents/_base.html' %}
+
+{% block title %}How to Propose a Talk{% endblock %}
+
+{% block content %}
+{% url 'page' path='speaking/cfp' as speaking_cfp_url %}
+{% url 'user_dashboard' as dashboard_url %}
+
+<h1>How to Propose a Talk?</h1>
+
+<p>For general proposal calling information, see <a href="{{ speaking_cfp_url }}">Call for Proposals</a>.</p>
+
+<p>First of all, thank you contributing to PyCon Taiwan! The following will help you submit an successful proposal. In the following, we are going to provide you the tips to make your proposal strong and informative and get the best chance of acceptance.</p>
+
+<ul>
+	<li>What’s your topic?</li>
+	<li>Who is your target audience?</li>
+	<li>What will the audience gain after your talk?</li>
+	<li>How will you organize your time slot?</li>
+</ul>
+
+<p>You will be asked to fill the following fields in your proposal:</p>
+
+<ul>
+	<li>Title</li>
+	<li>Category</li>
+	<li>Duration</li>
+	<li>Language</li>
+	<li>Abstract</li>
+	<li>Python Level</li>
+	<li>Objectives</li>
+	<li>Detailed Description (optional)</li>
+	<li>Outline (optional)</li>
+	<li>Supplementary (optional)</li>
+	<li>Recording Policy</li>
+	<li>Slide Link (optional)</li>
+</ul>
+
+<p>Hmmm, that is a lot. Well, if you skip all optional fields, it would only take you about 500 characters. But we encourage you to fill most of the fields to help reviewers understand your proposal.</p>
+
+<p>Some of the fields are for reviewers only, so don’t worry about spoilers:</p>
+
+<ul>
+	<li>Objectives</li>
+	<li>Outline</li>
+	<li>Supplementary</li>
+</ul>
+
+<p>If you are a very experienced speaker, you can directly enter the <a href="{{ dashboard_url }}">My PyCon</a> page to propose！</p>
+
+<p>Next we will give more detailed advice on each aspects.</p>
+
+
+<h2>Topics and General Advice</h2>
+
+<p>To pick a topic that suits PyCon Taiwan, you can first find out what accepted talks are about from the previous PyCons:</p>
+
+<ul>
+	<li><a href="//tw.pycon.org/2019/en-us/events/schedule/" target="_blank" rel="noopener">PyCon TW 2019</a></li>
+	<li><a href="//tw.pycon.org/2018/en-us/events/schedule/" target="_blank" rel="noopener">PyCon TW 2018</a></li>
+	<li><a href="//tw.pycon.org/2017/en-us/events/schedule/" target="_blank" rel="noopener">PyCon TW 2017</a></li>
+	<li><a href="//tw.pycon.org/2016/en-us/events/schedule/" target="_blank" rel="noopener">PyCon TW 2016</a></li>
+	<li><a href="//tw.pycon.org/2015apac/en/schedule/" target="_blank" rel="noopener">PyCon APAC 2015</a></li>
+	<li><a href="//tw.pycon.org/2014apac/en/program/" target="_blank" rel="noopener">PyCon APAC 2014</a></li>
+	<li><a href="//tw.pycon.org/2013/en/program/" target="_blank" rel="noopener">PyCon TW 2013</a></li>
+</ul>
+
+<h3>Good Ideas</h3>
+
+<ul>
+	<li>
+		<p>The abstract or detail description should include but not limited to:</p>
+		<ul>
+			<li>Who is the intended audience?</li>
+			<li>What should they know before the talk?</li>
+			<li>Is there any special domain knowledge required?</li>
+			<li>What will they get after my talk?</li>
+		</ul>
+	</li>
+	<li><p>The abstract and the content are as close as possible to the title.</p></li>
+	<li><p>Content must be original. Should let the audience and reviewer understand which part is original content in your proposal.</p></li>
+	<li><p>Enumerate each of your talk section in outline with estimated time length.</p></li>
+	<li><p>If your topic is not that familiar to normal Pythonistas, make sure you provide sufficient information through links of blog posts, wiki, source codes, or materials that help the understanding of your content.</p></li>
+</ul>
+
+
+<h3>Bad Ideas</h3>
+
+<ul>
+	<li>
+		<p>Avoid infomercials.</p>
+		<ul>
+			<li>Try not to merely sell your products or introduce how to use them in your talk. However, we do welcome talks about how your company solve the problem or your open source project that can benefit the general attendees.</li>
+		</ul>
+	</li>
+	<li><p>Don’t assume everyone in the review committee knows you. Please always submit a full proposal.</p></li>
+	<li><p>Avoiding plagiarism. We welcome all forms of sharing, but it should be clear which sections are original and which are citation of previous work.</p></li>
+</ul>
+
+
+<h2>How to Choose the Python Level</h2>
+
+<p>It is <em>very important</em> for you to choose an appropriate Python level.</p>
+
+<p>Your talk won’t be simply accepted because it is either super hard or deadly simple. The acceptance correlates with the specified Python level and your targeted audience.</p>
+
+<p>If your talk is for Python first-timers and it is about your Python learning experience and how you solve some tricky issues you face. This is a proper proposal. If your talk is about inspecting the Python memory usage and coordinating two GC systems together with reusing pointers, and you specify your talk as being novice or intermediate, it is not a good idea.</p>
+
+<p>For the extreme conditions (like topics above), it will be easy to decide. But topics lie somewhere in between are not. Therefore, there are more description below to help you find the proper level.</p>
+
+<h3>Novice</h3>
+
+<p>People who have little to none Python knowledge. One can expect them to have basic knowledge about Python syntax and control flow (e.g. if-else, for loops; functions), but the audience does not understand every modules in stdlib, nor the concepts of tricky variables visible scope and OOP (and MRO inheritance).</p>
+
+<p>Sharing your experience learning Python, leading a community perfectly fits in this level. Generally a talk about non-builtin Python packages, say pandas and Django, is not a novice talk. Unless people can actually learn all the content you give right after your talk.</p>
+
+<h3>Intermediate</h3>
+
+<p>The possible applications are more diverse than novice talks. Intermediate talks are for those who just learned how Python works and wish to know more how it can be used in different tasks. The talk topic can be about setting up web frameworks, talking to databases, monitoring the web traffic, auto trading in the stock market and so on.</p>
+
+<p>From previous submissions over the past few years, around a half of the talks should fall into this category. Note that we may contact you to adjust your talk to be novice or experienced based on your proposal.</p>
+
+<h3>Experienced</h3>
+
+<p>People coming to experienced talks should have good proficiency of audience’s Python (or programming) skill.</p>
+
+<p>The main difference between intermediate and experienced talks is that experienced talks assume more domain knowledge about the talk topic. For example, talks about optimization and tool’s internals should be at this level.</p>
+
+{% endblock content %}

--- a/src/templates/pycontw-2020/contents/en/speaking/tutorial.html
+++ b/src/templates/pycontw-2020/contents/en/speaking/tutorial.html
@@ -1,0 +1,47 @@
+{% extends 'contents/_base.html' %}
+
+{% block title %}How to Propose a Tutorial{% endblock title %}
+
+{% block content %}
+{% url 'page' path='speaking/cfp' as speaking_cfp_url %}
+{% url 'page' path='speaking/talk' as speaking_talk_url %}
+
+<h1>How to Propose a Tutorial?</h1>
+
+<p>For general proposal calling information, see <a href="{{ speaking_cfp_url }}">Call for Proposals</a>.</p>
+
+<p>First of all, thank you considering giving a tutorial in PyCon Taiwan 2020.</p>
+
+<p>Generally speaking, Good tutorials possess most of the traits good talks have. The most discernible differences of a tutorial from a <a href="{{ speaking_talk_url }}">talk</a> are the <em>hands-on</em> nature and the <em>longer duration</em>, and it's <em>paid</em>. By longer duration, generally more content is required and it should remain interesting and keep the attendees awake and hyped even after hours of lecture and exercises. By containing hands-on exercises, experience of teaching coding to people is necessary. You might also need teaching assistants who you should be able to comfortably communicate during the tutorial, usually at least two teaching assistants for a general class size of 20 people is needed.</p>
+
+<p>Both differences requires many times of practice and experience.  Therefore, a tutorial speaker usually satisfies at least one of the following prerequisites:</p>
+
+<ul>
+	<li>A previous tutorial speaker in any programming conferences or communities</li>
+	<li>More than one time of speaking experience in open source communities, preferably the local Python communities</li>
+	<li>Teaching assistant in previous tutorials</li>
+</ul>
+
+<p>We might ask you to give the tutorial to the community prior to the conference if you lack the experience.</p>
+
+<h2>Tutorial Duration</h2>
+
+<p>The length of the tutorial is 90 minutes.</p>
+
+<p>In our previous experiences, tutorials with length of 6 hours are exhausted for both instructors and students, students usually find it difficult to consistently follow in the second half of the tutorial.  Full-day tutorials require relatively experienced instructor, thus the length of the tutorial is 90 minutes this year. we strongly recommend you to clearly define <em>prerequisites</em> and <em>goals</em>, which helps building the best learning experience.</p>
+
+<h2>Tutorial Dates and Location</h2>
+
+<p>Tutorials are held in parallel with the main conference, therefore, the classroom would be outside of the venue. PyCon TW will discuss the time and location with the speaker, but the conference holds the final decision.</p>
+
+
+<h2>Charging Policy</h2>
+
+<p>No additional charge.</p>
+
+<h2>How to become a tutorial speaker?</h2>
+
+<p>The easiest and the best answer: Go speak and involved at the local Python communities!</p>
+<p>If you have any questions or suggestions, please don't hesitate to <a href="mailto:organizers@pycon.tw">contact us</a>.</p>
+
+{% endblock content %}

--- a/src/templates/pycontw-2020/contents/en/speaking/tutorial.html
+++ b/src/templates/pycontw-2020/contents/en/speaking/tutorial.html
@@ -12,7 +12,7 @@
 
 <p>First of all, thank you considering giving a tutorial in PyCon Taiwan 2020.</p>
 
-<p>Generally speaking, Good tutorials possess most of the traits good talks have. The most discernible differences of a tutorial from a <a href="{{ speaking_talk_url }}">talk</a> are the <em>hands-on</em> nature and the <em>longer duration</em>, and it's <em>paid</em>. By longer duration, generally more content is required and it should remain interesting and keep the attendees awake and hyped even after hours of lecture and exercises. By containing hands-on exercises, experience of teaching coding to people is necessary. You might also need teaching assistants who you should be able to comfortably communicate during the tutorial, usually at least two teaching assistants for a general class size of 20 people is needed.</p>
+<p>Generally speaking, Good tutorials possess most of the traits good talks have. The most discernible differences of a tutorial from a <a href="{{ speaking_talk_url }}">talk</a> are the <em>hands-on</em> nature and the <em>longer duration</em>. By longer duration, generally more content is required and it should remain interesting and keep the attendees awake and hyped even after hours of lecture and exercises. By containing hands-on exercises, experience of teaching coding to people is necessary. You might also need teaching assistants who you should be able to comfortably communicate during the tutorial, usually at least two teaching assistants for a general class size of 20 people is needed.</p>
 
 <p>Both differences requires many times of practice and experience.  Therefore, a tutorial speaker usually satisfies at least one of the following prerequisites:</p>
 


### PR DESCRIPTION
Add following en content :
- about: coc 
- event: open-spaces
- speaking: cfp, recording, talk, tutorial