### PR TITLE
Fix compatibility issue for Django 3.0

### DIFF
--- a/src/templates/default/reviews/review_form.html
+++ b/src/templates/default/reviews/review_form.html
@@ -1,6 +1,6 @@
 {% extends 'dashboard_base.html' %}
 
-{% load i18n staticfiles %}
+{% load i18n static %}
 {% load compress crispy_forms_tags %}
 {% load review_tools %}
 

--- a/src/templates/default/reviews/talk_proposal_list.html
+++ b/src/templates/default/reviews/talk_proposal_list.html
@@ -1,6 +1,6 @@
 {% extends 'dashboard_base.html' %}
 
-{% load i18n staticfiles %}
+{% load i18n static %}
 {% load compress crispy_forms_tags %}
 
 {% block dashboard_tablist %}


### PR DESCRIPTION
staticfiles template tag library is deprecated in Django 2.1. Change it to `{% load static %}`.

Quick Reference: https://stackoverflow.com/questions/55929472/
