### PR TITLE
Fix sticky footer bug in zh speaking/recording page

### DIFF
--- a/src/static/pycontw-2020/styles/_layout.scss
+++ b/src/static/pycontw-2020/styles/_layout.scss
@@ -20,6 +20,7 @@ footer {
 
 	padding: 80px 0 10px;
 	background-color: $jinger-bread;
+    flex-shrink: 0; // Fix for sticky footer
 
 	.footer-logos{
 		display: flex;
@@ -70,3 +71,14 @@ body.overlay-open {
 
 $background-deco-index: 0;
 $overlay-index: 99;
+
+
+// Fix for sticky footer
+html, body {
+    height: 100%;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+}

--- a/src/static/pycontw-2020/styles/_pycontw-year-ribbon.scss
+++ b/src/static/pycontw-2020/styles/_pycontw-year-ribbon.scss
@@ -1,4 +1,5 @@
 .year-ribbon {
+    flex: 1 0 auto; // Fix for sticky footer
 	display: flex;
 	align-content: center;
 	align-items: center;

--- a/src/static/pycontw-2020/styles/index.scss
+++ b/src/static/pycontw-2020/styles/index.scss
@@ -230,6 +230,7 @@ body {
 }
 
 .main-content {
+    flex: 1 0 auto; // Fix for sticky footer
     position: relative;
     overflow: hidden;
 

--- a/src/static/pycontw-2020/styles/page.scss
+++ b/src/static/pycontw-2020/styles/page.scss
@@ -47,6 +47,7 @@ main {
 	}
 
 	position: relative;
+    flex: 1 0 auto; // Fix for sticky footer
 
 	// Fancy h1 that merges into the navbar.
 	> h1:first-child {

--- a/src/static/pycontw-2020/styles/pages/_about.scss
+++ b/src/static/pycontw-2020/styles/pages/_about.scss
@@ -1,4 +1,5 @@
 .about-page .year-ribbon {
+    flex: 1 0 auto; // Fix for sticky footer
 	display: flex;
 	align-content: center;
 	align-items: center;


### PR DESCRIPTION
This fixes the bug when the content is not long enough and the footer isn't at the bottom, like the following screenshot:
![圖片](https://user-images.githubusercontent.com/484883/75605396-77c80d80-5b1d-11ea-81fd-b159eb825487.png)
