### PR TITLE
Fix prospectus scrolling

### DIFF
--- a/src/static/pycontw-2020/styles/_layout.scss
+++ b/src/static/pycontw-2020/styles/_layout.scss
@@ -82,3 +82,7 @@ body {
     display: flex;
     flex-direction: column;
 }
+
+body.scroll-x {
+    overflow-x: scroll;
+}

--- a/src/templates/pycontw-2020/contents/en/sponsor/prospectus.html
+++ b/src/templates/pycontw-2020/contents/en/sponsor/prospectus.html
@@ -2,6 +2,7 @@
 
 {% load i18n %}
 
+{% block body_class %}scroll-x{% endblock %}
 {% block title %}Sponsor{% endblock title %}
 {% block content %}
 

--- a/src/templates/pycontw-2020/contents/zh/sponsor/prospectus.html
+++ b/src/templates/pycontw-2020/contents/zh/sponsor/prospectus.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 
 {% block title %}Sponsor{% endblock title %}
+{% block body_class %}scroll-x{% endblock %}
 {% block content %}
 
 <section class="pill-title">


### PR DESCRIPTION
The table is larger than the page. But it won't scroll on x-axis. This PR fixes this problem by make it scrollable on the prospectus page.