### PR TITLE
sponsor: prospectus: rm gdoc registration link

### DIFF
--- a/src/templates/pycontw-2020/contents/en/sponsor/sponsor.html
+++ b/src/templates/pycontw-2020/contents/en/sponsor/sponsor.html
@@ -27,7 +27,6 @@
 <p>Our sponsorship partners are what makes PyCon Taiwan possible! We work closely with our partners in order to optimize what PyCon Taiwan can offer. Look for your participation!</p>
 
 <p>See our <a href="{{ prospectus_url }}">full prospectus</a> for Sponsorship Package</p>
-<p><a href="{{ SPONSOR_FORM_URL }}" target="_blank" rel="noopener">Click</a> to register Sponsorship</p>
 <p><a href="mailto:sponsorship@pycon.tw" target="_blank" rel="noopener">Talk</a> us about sponsorship</p>
 
 {% endblock content %}

--- a/src/templates/pycontw-2020/contents/zh/sponsor/sponsor.html
+++ b/src/templates/pycontw-2020/contents/zh/sponsor/sponsor.html
@@ -22,7 +22,6 @@
 	<li><p>為企業建立人才網絡</p></li>
 </ul>
 
-<p>歡迎參考 2020 PyCon Taiwan <a href="{{ prospectus_url }}">贊助書</a>，以了解 2020 PyCon Taiwan 贊助方案，或是<a href="mailto:sponsorship@pycon.tw">聯絡我們</a>，讓我們了解貴單位的需求！歡迎立即<a href="{{ SPONSOR_FORM_URL }}" target="_blank" rel="noopener">註冊</a>成為 2020 PyCon Taiwan 贊助商，一同共襄盛舉吧！</p>
+<p>歡迎參考 2020 PyCon Taiwan <a href="{{ prospectus_url }}">贊助書</a>，以了解 2020 PyCon Taiwan 贊助方案，或是<a href="mailto:sponsorship@pycon.tw">聯絡我們</a>，讓我們了解貴單位的需求！</p>
 
-<p class="closing-para">2020 PyCon Taiwan 贊助組志工</p>
 {% endblock content %}


### PR DESCRIPTION
The link points to 2019 gdoc. We will let the sponsorship team decide if we want to put the gdoc link back later.