### PR TITLE
Update makemessage instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For maintainer update transifex
 # maybe
 # pip install -U transifex-client
 
-python manage.py makemessages
+python manage.py makemessages --locale _src
 
 tx push -s
 ```


### PR DESCRIPTION
I think the `makemessages` command changed over versions. We need to specify `--locale _src` to make messages to the _src locale.