### PR TITLE
Fix get_path_category() for production url pattern search

### DIFF
--- a/src/core/templatetags/pycontw_tools.py
+++ b/src/core/templatetags/pycontw_tools.py
@@ -14,7 +14,7 @@ def message_bootstrap_class_str(message):
 @register.filter
 def get_path_category(url):
     pattern = r'/(?P<lang>zh\-hant|en\-us)/(?P<category>[0-9a-z-]*)/'
-    result = re.match(pattern, url)
+    result = re.search(pattern, url)
     if not result:
         return 'unmatched'
     return result.groupdict().get('category', 'uncategorized')


### PR DESCRIPTION
### **[WHY]**

As mentioned in the [comment](https://github.com/pycontw/pycon.tw/pull/696#issuecomment-602017232) of #696, the url pattern in the development environment is `/<LANGUAGE>/<CATEGORY>/.../...` but it's `/<LANGUAGE>/<CATEGORY>/.../...` in the production/staging environment, which is not supported by the customized template filter `get_path_category()`.

### **[HOW]**

Change the regex matching function in `get_path_category()` from `re.match()` to `re.search()` to support two aforementioned url formats.