### PR TITLE
Fix navbar display issue in safari

### DIFF
--- a/src/static/pycontw-2020/styles/page.scss
+++ b/src/static/pycontw-2020/styles/page.scss
@@ -8,8 +8,6 @@ body {
 
 .page-hero {
 	background-color: $top-navbar-background-color;
-	display: flex;
-	flex-direction: row;
 	height: $menu-desktop-height - 20;
 	@include on-desktop;
 }
@@ -26,9 +24,9 @@ body {
 		margin: 0 40px;
 		display: flex;
 		flex-direction: row;
-		width: 100%;
 		justify-content: space-between;
 		align-items: center;
+		padding: 0;
 	}
 }
 


### PR DESCRIPTION
I have no idea why I made the navbar as flex at the first place.
Maybe I was just trying to make "My PyCon" rightmost, and try to
do that by making the nav items and "My PyCon" as flex items.

But in the end, "My PyCon" remains as an item inside the nav,
which makes it only one element inside the flex, and this cause
a problem in Safari, making the entire flex container with no
height, so the display is wrong and you cannot hit any item on the
menu.