### PR TITLE
Generate .mo files automatically per deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ local.env
 venv/
 /src/assets/
 local.db
+*.mo
 
 # NPM
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6-buster
 
 ENV PYTHONUNBUFFERED 1
 ENV BASE_DIR /usr/local
@@ -14,6 +14,13 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 # Add bin directory used by `pip install --user`
 ENV PATH "/home/docker/.local/bin:${PATH}"
+
+# Infrastructure tools
+# gettext is used for django to compile .po to .mo files.
+RUN apt-get update
+RUN apt-get install apt-utils -y
+RUN apt-get update
+RUN apt-get install gettext python3-pip -y
 
 # Install Node and Yarn from upstream
 RUN curl -o- $NVM_INSTALLER_URL | bash \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - -c
       - |
         set -o errexit -o nounset -o pipefail
+        python3 manage.py compilemessages
         python3 manage.py migrate
         python3 manage.py collectstatic --no-input
 


### PR DESCRIPTION
We did not automate the flow so we needed to compile .po files locally
first and then commit the corresponding .mo files into the repository.
Automate the generation of .mo files will free us from committing .mo
binaries into a repository.

# Verified on Staging Site Already

verification steps, on the staging site:
    1. `find ./ -name "*.mo" -exec rm {} \;` to remove all existing .mo files
    1. `docker-compose up --build -d`
    1. `docker exec -it <container ID> bash` and check the timestamp of the generated .mo files `find ./ --name "*.mo" -exec ls -alh {} \;`
    1. also, check the staging site pages to make sure the translation is working.

