### PR TITLE
Use an empty ALLOWED_HOSTS setting

### DIFF
--- a/src/pycontw2016/settings/base.py
+++ b/src/pycontw2016/settings/base.py
@@ -69,7 +69,7 @@ if os.path.exists(env_file):
 # Raises ImproperlyConfigured exception if SECRET_KEY not in os.environ
 SECRET_KEY = env('SECRET_KEY')
 
-ALLOWED_HOSTS = ['0.0.0.0', 'localhost']  # for connecting to db in dev env
+ALLOWED_HOSTS = []
 
 # Database
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases


### PR DESCRIPTION
## Types of changes

- [ ] **Bugfix**
- [ ] **New feature**
- [x] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
Revert the changes made to src/pycontw2016/settings/base.py in #783 (specifically a03d7880).

For development environment the ALLOWED_HOSTS setting canbe left as an empty list, since [Django documentation stated](https://docs.djangoproject.com/en/3.0/ref/settings/#allowed-hosts) that

> When DEBUG is True and ALLOWED_HOSTS is empty, the host is validated against ['localhost', '127.0.0.1', '[::1]'].

See #792 for more detail.

## Steps to Test This Pull Request
```cmd
cat src/pycontw2016/settings/base.py | grep ALLOWED_HOSTS
```

## Expected behavior
In ALLOWED_HOSTS setting in src/pycontw2016/settings/base.py is set to an empty list, which was what it was set to previously

## Related Issue
#792 