### PR TITLE
Reraise template-resolution exceptions in development mode

### DIFF
--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -31,6 +31,8 @@ class TemplateExistanceStatusResponse(TemplateResponse):
         try:
             return super().resolve_template(template)
         except (UnicodeEncodeError, TemplateDoesNotExist):
+            if settings.DEBUG:
+                raise
             raise Http404
 
 


### PR DESCRIPTION
## Types of changes
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
I tried to update pages found at `/events/*`, but keep on getting 404 Not Found error even in development mode without any more information provided. After tracing through the code I realized it is because many of those views use the TemplateExistanceStatusResponse response class, which hides the TemplateDoesNotExist exception. (I guess because it introduce too much logging noise on production?)

This is of course due to unfamiliarity with Django and the code-base itself on my part, but I think it maybe more helpful to reraise TemplateDoesNotExist or UnicodeEncodeError exception instead of hiding it behind a 404 Not Found when we're in development mode; so it's easier to diagnose the issue.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Start the containerized development environment
2. Add a talk event
3. Access the talk detail page at `http://localhost:8000/zh-hant/events/talk/$talk_id/`

## Expected behavior
A page showing `django.template.exceptions.TemplateDoesNotExist: events/talk_detail.html` and the traceback.
