### PR TITLE
update description of translation in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ And migrate the database:
 
     python manage.py createsuperuser
 
+#### Compile localized translation
 
+    python manage.py compilemessages
 
 Now you’re all set!
 
@@ -149,38 +151,6 @@ Follow the [GitHub Flow](https://guides.github.com/introduction/flow/), please *
 
 We strongly recommend you configure your editor to match our coding styles. You can do this manually, or use an [EditorConfig plugin](http://editorconfig.org/#download) if your editor supports it. An `.editorconfig` file has already been attached to the repository.
 
-
-## Internationalisation
-
-Translations are hosted on [Transifex](https://www.transifex.com/pycon-taiwan/pycon-tw/). When new commits are added into master branch, Travis CI will automatically push new translation strings to Transifex, so simply fix or edit the translation online.
-
-### Update translation
-
-Translation updates into code base are done **manually** under `src/`. You need to [configure the Transifex client](https://docs.transifex.com/client/client-configuration) first by adding the file `~/.transifexrc`.
-
-For maintainer update transifex
-
-```
-# maybe
-# pip install -U transifex-client
-
-python manage.py makemessages --locale _src
-
-tx push -s
-```
-
-Then update the translation in transifex.
-
-Old translation files will stop `tx pull` updating if they have later modified time, which they generally have when they are pulled from the remote repo. So old translation files should be removed first:
-
-    rm locale/en_US/LC_MESSAGES/django.*
-    rm locale/zh_Hant/LC_MESSAGES/django.*
-    # ... more languages
-
-Run `tx pull` to get newer translation and recompile the PO files:
-
-    tx pull -a
-    python manage.py compilemessages -x _src
 
 ## Deployment
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,7 +54,7 @@ certifi>=2019.11.28
 
 # Faker is a Python package that generates fake data for you.
 # https://faker.readthedocs.io/en/master/
-# 
+#
 # Note(yychen): I cannot find where this package is used.
 # It was originally called "fake-factory", and the name has changed
 # to "Faker"
@@ -89,7 +89,3 @@ sortedcontainers==2.1.0
 # Tabulate, an utility for pretty-print tabular data
 # https://bitbucket.org/astanin/python-tabulate
 tabulate==0.8.6
-
-# Transifex, an online translation collaboration platform
-# http://docs.transifex.com/client/
-transifex-client==0.13.7


### PR DESCRIPTION
(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)

## Types of changes
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [x] **Documentation Update**
- [ ] **Other (please describe)**

## Description
移除readme.md對於tx的描述(該套件已棄用)，將主要的翻譯方式改為輸入```python manage.py compilemessages```指令

## Steps to Test This Pull Request
```
python manage.py compilemessages
```

## Expected behavior
將```/src/locale/{各國語系}/LC_MESSAGES/django.po```編譯成同路徑的```django.mo```(django i18n執行會讀的檔案)

## Related Issue
https://github.com/pycontw/pycon.tw/issues/761
