### PR TITLE
Correct the path of info image on passion-fruit page

### DIFF
--- a/src/templates/pycontw-2020/contents/en/events/passion-fruit.html
+++ b/src/templates/pycontw-2020/contents/en/events/passion-fruit.html
@@ -14,7 +14,7 @@
     <h1>第壹次Python NPF百香果 x 南投.py</h1>
 </section>
 
-<img src="{% static 'pycontw-2020/assets/warm-session/passion-fruit/info.png' %}" width="100%">
+<img src="{% static 'pycontw-2020/assets/warm-session/passion-fruit/Info.png' %}" width="100%">
 <p>Python NPF百香果是今年一個由PyCon Taiwan所籌備的小型線上會議，在疫情肆虐全球的情況下，我們希望藉由這樣的線上活動來拉近彼此間的距離，並利用此本次活動向大家揭露南投.py的神秘面紗！</p>
 
 <ul>

--- a/src/templates/pycontw-2020/contents/zh/events/passion-fruit.html
+++ b/src/templates/pycontw-2020/contents/zh/events/passion-fruit.html
@@ -14,7 +14,7 @@
     <h1>第壹次Python NPF百香果 x 南投.py</h1>
 </section>
 
-<img src="{% static 'pycontw-2020/assets/warm-session/passion-fruit/info.png' %}" width="100%">
+<img src="{% static 'pycontw-2020/assets/warm-session/passion-fruit/Info.png' %}" width="100%">
 <p>Python NPF百香果是今年一個由PyCon Taiwan所籌備的小型線上會議，在疫情肆虐全球的情況下，我們希望藉由這樣的線上活動來拉近彼此間的距離，並利用此本次活動向大家揭露南投.py的神秘面紗！</p>
 
 <ul>


### PR DESCRIPTION
## Types of changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

In the changes in PR #785, the path of event info image is `pycontw-2020/assets/warm-session/passion-fruit/Info.png` but  `pycontw-2020/assets/warm-session/passion-fruit/info.png` is given on both en & zh pages. It can be displayed successfully in the environment with case-insensitive settings but failed in our production environment.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to `<host>/2020/<lang>/events/passion-fruit/`.
2. The event info image should be displayed successfully.

## Expected behavior
The image is shown.

## Related Issue
See #767 for the requirements.

## More Information
This is what we saw on staging:
![image](https://user-images.githubusercontent.com/24987826/86079658-92a69080-bac3-11ea-8d13-c4bc2e1e5163.png)

