### PR TITLE
Compile localized translation when starting development environment

### DIFF
--- a/contrib/docker-entrypoint.sh
+++ b/contrib/docker-entrypoint.sh
@@ -3,4 +3,6 @@ echo 'Run migration'
 python3 /app/src/manage.py migrate
 echo 'Create super user'
 python3 /app/src/manage.py createsuperuser --noinput || echo "Super user already created"
+echo 'Compile localized translation'
+python3 /app/src/manage.py compilemessages
 exec "$@"


### PR DESCRIPTION
## Types of changes
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [x] **Other**:  development environment enhancement

## Description
Compile localized translation when starting development environment

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Start the development environment with the `enter_dev_env.sh` script
2. Open `localhost:8000/zh-hant/` with web browser

## Expected behavior
Content of the webpage is displayed in Traditional Chinese.

## Related Issue
See #761 for more context.