### PR TITLE
modify_TaichungPy_community_link

### DIFF
--- a/src/templates/pycontw-2020/contents/en/about/community.html
+++ b/src/templates/pycontw-2020/contents/en/about/community.html
@@ -35,7 +35,7 @@
 <p>Before Kaohsiung.py was founded, Python enthusiasts, like TooMore and CD, sometimes shared Python-related topics in the KSDG meetups. Founder of Kaohsiung.py is Victor Gau. He joined Tainan.py regularly until one day he had an accident with a speeding motorcycle on the way from Tainan to Kaohsiung. The accident induced him to launch a Python community in Kaohsiung. Therefore, Kaohsiung Python User Group was founded in 2014. In addition to casual meetups, which invites specialist from other cities, there is a regular gathering in Wenzao Ursuline University of Languages on one Monday night every month. They welcome anyone who passes by Kaohsiung to join the events.</p>
 
 
-<h2><a href="http://www.meetup.com/Taichung-Python-Meetup/" target="_blank" rel="noopener">Taichung &mdash; Taichung.py</a></h2>
+<h2><a href="https://www.facebook.com/groups/780250978715991/" target="_blank" rel="noopener">Taichung &mdash; Taichung.py</a></h2>
 
 <p>Taichung.py was started in 2014 by Prof. Yuan-Liang Tang and several enthusiasts. The events were held at restaurants or coffee shops until later Microprogram Co. supported the event venue. Now the events are held monthly in Saturday afternoon, which is best suited for a walk to have some snacks in Fengjia Night Market after the event.</p>
 

--- a/src/templates/pycontw-2020/contents/zh/about/community.html
+++ b/src/templates/pycontw-2020/contents/zh/about/community.html
@@ -36,7 +36,7 @@
 <p>在 Kaohsiung.py 之前，高雄的同好如 TooMore、CD 等，不定期會安排 Python 的餐敘，在 KSDG 偶爾會有 Python 的主題分享。Victor Gau 是 Kaohsiung.py 的發起人，在 Kaohsiung.py 成立之前，Victor定期的會去參加 Joe 安排的 Tainan.py 的活動，直到有一次從台南回高雄時，與超速的機車發生擦撞，後續繁瑣的事故處理程序，讓 Victor 萌生在高雄成立社群減少交通奔波的念頭。2014 年，Victor 在高雄發起了 Kaohsiung Python UserGroup，除了不定期的在禮拜六下午安排外縣市的專家到高雄來分享新技術，每個月也會挑一個星期一晚上，在文藻外語大學聚會。竭誠歡迎大家路過高雄時，來參加 Kaohsiung.py 的聚會。</p>
 
 
-<h2><a href="http://www.meetup.com/Taichung-Python-Meetup/" target="_blank" rel="noopener">台中 Taichung.py</a></h2>
+<h2><a href="https://www.facebook.com/groups/780250978715991/" target="_blank" rel="noopener">台中 Taichung.py</a></h2>
 
 <p>唐元亮老師與熱心友人們，也在 2014 年發起了 Taichung.py。初期流浪在各餐廳與咖啡館，後期由微程式科技提供場地空間，告別流浪的生活。每月聚會一次，時間在星期六下午，剛好可以在聚會結束後，到附近的逢甲夜市散步、覓食。</p>
 


### PR DESCRIPTION
Modify Taichung.py's community link to facebook group.
(Tho old one has been closed)

(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)

## Types of changes
Please put an `x` in the box that applies

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**

Taichung.py 的meetup社群已移除，因此將原連結改為[Taichung.py的facebook社團](https://www.facebook.com/groups/780250978715991/)連結

## Steps to Test This Pull Request
```python manage.py runserver```

## Expected behavior
A clear and concise description of what you expected to happen.

點選[在地Python社群](https://tw.pycon.org/2020/zh-hant/about/community/)中的Taichung.py
會連結至[Taichung.py的facebook社團](https://www.facebook.com/groups/780250978715991/)

## Related Issue
#825 
