### PR TITLE
List talks instead of CfP in the landing page

### DIFF
--- a/src/templates/pycontw-2020/index.html
+++ b/src/templates/pycontw-2020/index.html
@@ -43,9 +43,9 @@
     </section>
 
     <section class="index-actions">
-        <a class="index-big-button color-jinger-bread" href="{% url 'page' path='speaking/cfp' %}">
+        <a class="index-big-button color-jinger-bread" href="{% url 'page' path='events/talks' %}">
             <i class="icon icon-speaking"></i>
-            <div>{% trans 'Call for Proposals' %}</div>
+            <div>{% trans 'Talks' %}</div>
         </a>
 
         <a class="index-big-button color-imperial" href="{{ VOLUNTEER_FORM_URL }}" target="_blank" rel="noopener">


### PR DESCRIPTION
## Types of changes
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [x] **Other (Update the link of the landing page)**

## Description
The CfP has ended and the selected talks are announced. Let's update the portal of the landing page with the talk list instead of CfP.

## Steps to Test This Pull Request
1. Go to the index page
2. Click "Talks" button

## Expected behavior
You will be redirected to the "talk list" page.

## More Information
**Screenshots** of the changed page
![Selection_193](https://user-images.githubusercontent.com/3217432/88373373-51578700-cdca-11ea-9d0c-e212f912bd28.png)


![Selection_194](https://user-images.githubusercontent.com/3217432/88373389-5583a480-cdca-11ea-8d34-d8faa3342c10.png)


