### PR TITLE
feat: 🎸 add pycontw 2020 style

### DIFF
--- a/src/locale/en_US/LC_MESSAGES/django.po
+++ b/src/locale/en_US/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PyCon TW\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-01 12:10+0800\n"
+"POT-Creation-Date: 2020-08-07 02:08+0800\n"
 "PO-Revision-Date: 2020-03-17 11:46+0000\n"
 "Last-Translator: Tom Chen <ctchen@gmail.com>\n"
 "Language-Team: English (United States) (http://www.transifex.com/pycon-"
@@ -426,6 +426,7 @@ msgstr "HTML"
 #: templates/pycontw-2019/_includes/portal.html:4
 #: templates/pycontw-2019/events/schedule.html:6
 #: templates/pycontw-2019/events/schedule.html:20
+#: templates/pycontw-2020/_includes/menu.html:70
 #: templates/pycontw-2020/_includes/portal.html:4
 #: templates/pycontw-2020/events/schedule.html:6
 #: templates/pycontw-2020/events/schedule.html:20
@@ -1074,15 +1075,15 @@ msgstr "Prefer 45min"
 msgid "Day 3"
 msgstr "Day 3"
 
-#: reviews/admin.py:50
+#: reviews/admin.py:51
 msgid "Key"
 msgstr "Key"
 
-#: reviews/admin.py:52
+#: reviews/admin.py:53
 msgid "Value"
 msgstr "Value"
 
-#: reviews/admin.py:67
+#: reviews/admin.py:68
 msgid "dumped data"
 msgstr "dumped data"
 
@@ -2036,6 +2037,7 @@ msgstr "Events"
 #: templates/pycontw-2016/_includes/nav/front_nav.html:39
 #: templates/pycontw-2018/_includes/menu.html:53
 #: templates/pycontw-2019/_includes/menu.html:58
+#: templates/pycontw-2020/_includes/menu.html:69
 msgid "Overview"
 msgstr "Overview"
 
@@ -2052,7 +2054,7 @@ msgstr "Overview"
 #: templates/pycontw-2020/contents/_default/events/keynotes.html:6
 #: templates/pycontw-2020/contents/_default/events/keynotes.html:17
 #: templates/pycontw-2020/contents/_default/events/keynotes.html:21
-#: templates/pycontw-2020/contents/en/events/overview.html:20
+#: templates/pycontw-2020/contents/en/events/overview.html:21
 #: templates/pycontw-2020/contents/zh/events/overview.html:21
 msgid "Keynotes"
 msgstr "Keynotes"
@@ -2073,10 +2075,13 @@ msgstr "Keynotes"
 #: templates/pycontw-2019/events/talk_list.html:6
 #: templates/pycontw-2019/events/talk_list.html:10
 #: templates/pycontw-2020/_includes/menu.html:89
-#: templates/pycontw-2020/contents/en/events/overview.html:27
+#: templates/pycontw-2020/contents/en/events/overview.html:28
+#: templates/pycontw-2020/contents/en/events/overview.html:63
 #: templates/pycontw-2020/contents/zh/events/overview.html:28
+#: templates/pycontw-2020/contents/zh/events/overview.html:63
 #: templates/pycontw-2020/events/talk_list.html:6
 #: templates/pycontw-2020/events/talk_list.html:11
+#: templates/pycontw-2020/index.html:48
 msgid "Talks"
 msgstr "Talks"
 
@@ -2084,6 +2089,8 @@ msgstr "Talks"
 #: templates/pycontw-2018/_includes/menu.html:68
 #: templates/pycontw-2018/contents/en/events/overview.html:30
 #: templates/pycontw-2018/contents/zh/events/overview.html:30
+#: templates/pycontw-2020/contents/en/events/overview.html:72
+#: templates/pycontw-2020/contents/zh/events/overview.html:72
 msgid "Sprints"
 msgstr "Sprints"
 
@@ -2270,7 +2277,7 @@ msgstr ""
 #: templates/pycontw-2019/contents/zh/events/overview.html:35
 #: templates/pycontw-2019/events/tutorial_list.html:6
 #: templates/pycontw-2019/events/tutorial_list.html:10
-#: templates/pycontw-2020/contents/en/events/overview.html:34
+#: templates/pycontw-2020/contents/en/events/overview.html:35
 #: templates/pycontw-2020/contents/zh/events/overview.html:35
 #: templates/pycontw-2020/events/tutorial_list.html:6
 #: templates/pycontw-2020/events/tutorial_list.html:10
@@ -2483,6 +2490,7 @@ msgstr "dashboard"
 #: templates/pycontw-2019/contents/_default/portal.html:6
 #: templates/pycontw-2019/contents/_default/portal.html:12
 #: templates/pycontw-2019/index.html:30
+#: templates/pycontw-2020/_includes/menu.html:72
 #: templates/pycontw-2020/contents/_default/portal.html:6
 #: templates/pycontw-2020/contents/_default/portal.html:12
 msgid "Portal"
@@ -2686,12 +2694,14 @@ msgstr "Our Partners"
 
 #: templates/pycontw-2018/_includes/menu.html:50
 #: templates/pycontw-2019/_includes/menu.html:55
+#: templates/pycontw-2020/_includes/menu.html:65
 msgctxt "menu"
 msgid "Conference"
 msgstr "Conference"
 
 #: templates/pycontw-2018/_includes/menu.html:57
 #: templates/pycontw-2019/_includes/menu.html:60
+#: templates/pycontw-2020/_includes/menu.html:71
 msgid "Recording"
 msgstr "Recording"
 
@@ -2712,7 +2722,7 @@ msgstr "Learning"
 #: templates/pycontw-2019/_includes/menu.html:74
 #: templates/pycontw-2019/contents/en/events/overview.html:46
 #: templates/pycontw-2019/contents/zh/events/overview.html:49
-#: templates/pycontw-2020/contents/en/events/overview.html:46
+#: templates/pycontw-2020/contents/en/events/overview.html:47
 #: templates/pycontw-2020/contents/zh/events/overview.html:49
 msgid "Open Spaces"
 msgstr "Open Spaces"
@@ -2725,6 +2735,7 @@ msgstr "Registration"
 
 #: templates/pycontw-2018/_includes/menu.html:79
 #: templates/pycontw-2019/_includes/menu.html:84
+#: templates/pycontw-2020/_includes/menu.html:106
 msgid "Conference Ticket"
 msgstr "Conference Ticket"
 
@@ -2907,7 +2918,6 @@ msgstr "Speaker"
 
 #: templates/pycontw-2018/events/talk_list.html:13
 #: templates/pycontw-2019/events/talk_list.html:13
-#: templates/pycontw-2020/events/talk_list.html:15
 msgid ""
 "The two conference days are packed with talks about Python by speakers from "
 "Taiwan and around the world. The talks will be either 30- or 45-minute long. "
@@ -3001,6 +3011,7 @@ msgid "Program Book"
 msgstr "Program Book"
 
 #: templates/pycontw-2019/_includes/sponsors.html:53
+#: templates/pycontw-2020/_includes/sponsors.html:50
 msgid "Redirect to official website"
 msgstr "Redirect to official website"
 
@@ -3058,7 +3069,6 @@ msgid "Lecturer"
 msgstr "Lecturer"
 
 #: templates/pycontw-2019/events/tutorial_list.html:13
-#: templates/pycontw-2020/events/tutorial_list.html:13
 msgid ""
 "Tutorial are events held as part of the main conference, but attendees need "
 "to register separately in order to join. They are either half- or one-day "
@@ -3084,6 +3094,31 @@ msgstr "Register"
 msgid "Warm-Up Session"
 msgstr ""
 
+#: templates/pycontw-2020/events/talk_list.html:15
+#, fuzzy
+#| msgid ""
+#| "The two conference days are packed with talks about Python by speakers "
+#| "from Taiwan and around the world. The talks will be either 30- or 45-"
+#| "minute long. Three tracks of talks will be delivered simultaneously, all "
+#| "with different topics and difficulties. We suggest you to plan "
+#| "beforehand, and choose what you want to listen based on your interests. "
+#| "Many people take notes on the program schedule before the meeting so they "
+#| "don't end up in the wrong place."
+msgid ""
+"The two conference days are packed with talks about Python by speakers from "
+"Taiwan and around the world. The talks will be either 15- or 30-minute long. "
+"Three tracks of talks will be delivered simultaneously, all with different "
+"topics and difficulties. We suggest you to plan beforehand, and choose what "
+"you want to listen based on your interests. Many people take notes on the "
+"program schedule before the meeting so they don't end up in the wrong place."
+msgstr ""
+"The two conference days are packed with talks about Python by speakers from "
+"Taiwan and around the world. The talks will be either 30- or 45-minute long. "
+"Three tracks of talks will be delivered simultaneously, all with different "
+"topics and difficulties. We suggest you to plan beforehand, and choose what "
+"you want to listen based on your interests. Many people take notes on the "
+"program schedule before the meeting so they don’t end up in the wrong place."
+
 #: templates/pycontw-2020/events/talk_list.html:41
 #, fuzzy, python-format
 #| msgid "speaker name"
@@ -3105,9 +3140,17 @@ msgid ""
 "more comfortably and closely."
 msgstr ""
 
-#: templates/pycontw-2020/index.html:48
-msgid "Call for Proposals"
-msgstr "Call for Proposals"
+#: templates/pycontw-2020/events/tutorial_list.html:13
+msgid ""
+"Tutorial are events held as part of the main conference, but attendees need "
+"to register separately in order to join. They are 90-minute events held to "
+"help participants better understand talks during the conference, or get "
+"their hands on more Python applications."
+msgstr ""
+"Tutorial are events held as part of the main conference, but attendees need "
+"to register separately in order to join. They are 90-minute events held to "
+"help participants better understand talks during the conference, or get "
+"their hands on more Python applications."
 
 #: templates/pycontw-2020/index.html:58
 msgid "Sponsor PyCon TW"
@@ -3330,6 +3373,9 @@ msgstr ""
 #: users/views.py:130
 msgid "Password reset successful. You can now login."
 msgstr "Password reset successful. You can now login."
+
+#~ msgid "Call for Proposals"
+#~ msgstr "Call for Proposals"
 
 #, fuzzy
 #~| msgid ""

--- a/src/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/src/locale/zh_Hant/LC_MESSAGES/django.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PyCon TW\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-01 12:10+0800\n"
+"POT-Creation-Date: 2020-08-07 02:09+0800\n"
 "PO-Revision-Date: 2020-03-19 11:22+0000\n"
 "Last-Translator: Tom Chen <ctchen@gmail.com>\n"
 "Language-Team: Chinese Traditional (http://www.transifex.com/pycon-taiwan/"
@@ -431,6 +431,7 @@ msgstr "HTML"
 #: templates/pycontw-2019/_includes/portal.html:4
 #: templates/pycontw-2019/events/schedule.html:6
 #: templates/pycontw-2019/events/schedule.html:20
+#: templates/pycontw-2020/_includes/menu.html:70
 #: templates/pycontw-2020/_includes/portal.html:4
 #: templates/pycontw-2020/events/schedule.html:6
 #: templates/pycontw-2020/events/schedule.html:20
@@ -1033,15 +1034,15 @@ msgstr "偏好 45 分鐘"
 msgid "Day 3"
 msgstr "第 3 天"
 
-#: reviews/admin.py:50
+#: reviews/admin.py:51
 msgid "Key"
 msgstr "鍵"
 
-#: reviews/admin.py:52
+#: reviews/admin.py:53
 msgid "Value"
 msgstr "值"
 
-#: reviews/admin.py:67
+#: reviews/admin.py:68
 msgid "dumped data"
 msgstr "匯出資料"
 
@@ -1971,6 +1972,7 @@ msgstr "活動"
 #: templates/pycontw-2016/_includes/nav/front_nav.html:39
 #: templates/pycontw-2018/_includes/menu.html:53
 #: templates/pycontw-2019/_includes/menu.html:58
+#: templates/pycontw-2020/_includes/menu.html:69
 msgid "Overview"
 msgstr "總覽"
 
@@ -1987,7 +1989,7 @@ msgstr "總覽"
 #: templates/pycontw-2020/contents/_default/events/keynotes.html:6
 #: templates/pycontw-2020/contents/_default/events/keynotes.html:17
 #: templates/pycontw-2020/contents/_default/events/keynotes.html:21
-#: templates/pycontw-2020/contents/en/events/overview.html:20
+#: templates/pycontw-2020/contents/en/events/overview.html:21
 #: templates/pycontw-2020/contents/zh/events/overview.html:21
 msgid "Keynotes"
 msgstr "基調演講"
@@ -2008,10 +2010,13 @@ msgstr "基調演講"
 #: templates/pycontw-2019/events/talk_list.html:6
 #: templates/pycontw-2019/events/talk_list.html:10
 #: templates/pycontw-2020/_includes/menu.html:89
-#: templates/pycontw-2020/contents/en/events/overview.html:27
+#: templates/pycontw-2020/contents/en/events/overview.html:28
+#: templates/pycontw-2020/contents/en/events/overview.html:63
 #: templates/pycontw-2020/contents/zh/events/overview.html:28
+#: templates/pycontw-2020/contents/zh/events/overview.html:63
 #: templates/pycontw-2020/events/talk_list.html:6
 #: templates/pycontw-2020/events/talk_list.html:11
+#: templates/pycontw-2020/index.html:48
 msgid "Talks"
 msgstr "一般演講"
 
@@ -2019,6 +2024,8 @@ msgstr "一般演講"
 #: templates/pycontw-2018/_includes/menu.html:68
 #: templates/pycontw-2018/contents/en/events/overview.html:30
 #: templates/pycontw-2018/contents/zh/events/overview.html:30
+#: templates/pycontw-2020/contents/en/events/overview.html:72
+#: templates/pycontw-2020/contents/zh/events/overview.html:72
 msgid "Sprints"
 msgstr "衝刺開發"
 
@@ -2202,7 +2209,7 @@ msgstr ""
 #: templates/pycontw-2019/contents/zh/events/overview.html:35
 #: templates/pycontw-2019/events/tutorial_list.html:6
 #: templates/pycontw-2019/events/tutorial_list.html:10
-#: templates/pycontw-2020/contents/en/events/overview.html:34
+#: templates/pycontw-2020/contents/en/events/overview.html:35
 #: templates/pycontw-2020/contents/zh/events/overview.html:35
 #: templates/pycontw-2020/events/tutorial_list.html:6
 #: templates/pycontw-2020/events/tutorial_list.html:10
@@ -2413,6 +2420,7 @@ msgstr "控制面板"
 #: templates/pycontw-2019/contents/_default/portal.html:6
 #: templates/pycontw-2019/contents/_default/portal.html:12
 #: templates/pycontw-2019/index.html:30
+#: templates/pycontw-2020/_includes/menu.html:72
 #: templates/pycontw-2020/contents/_default/portal.html:6
 #: templates/pycontw-2020/contents/_default/portal.html:12
 msgid "Portal"
@@ -2608,12 +2616,14 @@ msgstr "我們的夥伴"
 
 #: templates/pycontw-2018/_includes/menu.html:50
 #: templates/pycontw-2019/_includes/menu.html:55
+#: templates/pycontw-2020/_includes/menu.html:65
 msgctxt "menu"
 msgid "Conference"
 msgstr "議程"
 
 #: templates/pycontw-2018/_includes/menu.html:57
 #: templates/pycontw-2019/_includes/menu.html:60
+#: templates/pycontw-2020/_includes/menu.html:71
 msgid "Recording"
 msgstr "錄影"
 
@@ -2634,7 +2644,7 @@ msgstr "學習"
 #: templates/pycontw-2019/_includes/menu.html:74
 #: templates/pycontw-2019/contents/en/events/overview.html:46
 #: templates/pycontw-2019/contents/zh/events/overview.html:49
-#: templates/pycontw-2020/contents/en/events/overview.html:46
+#: templates/pycontw-2020/contents/en/events/overview.html:47
 #: templates/pycontw-2020/contents/zh/events/overview.html:49
 msgid "Open Spaces"
 msgstr "開放空間"
@@ -2647,6 +2657,7 @@ msgstr "註冊"
 
 #: templates/pycontw-2018/_includes/menu.html:79
 #: templates/pycontw-2019/_includes/menu.html:84
+#: templates/pycontw-2020/_includes/menu.html:106
 msgid "Conference Ticket"
 msgstr "會議門票"
 
@@ -2829,10 +2840,18 @@ msgstr "講者"
 
 #: templates/pycontw-2018/events/talk_list.html:13
 #: templates/pycontw-2019/events/talk_list.html:13
-#: templates/pycontw-2020/events/talk_list.html:15
+#, fuzzy
+#| msgid ""
+#| "The two conference days are packed with talks about Python by speakers "
+#| "from Taiwan and around the world. The talks will be either 15- or 30-"
+#| "minute long. Three tracks of talks will be delivered simultaneously, all "
+#| "with different topics and difficulties. We suggest you to plan "
+#| "beforehand, and choose what you want to listen based on your interests. "
+#| "Many people take notes on the program schedule before the meeting so they "
+#| "don't end up in the wrong place."
 msgid ""
 "The two conference days are packed with talks about Python by speakers from "
-"Taiwan and around the world. The talks will be either 15- or 30-minute long. "
+"Taiwan and around the world. The talks will be either 30- or 45-minute long. "
 "Three tracks of talks will be delivered simultaneously, all with different "
 "topics and difficulties. We suggest you to plan beforehand, and choose what "
 "you want to listen based on your interests. Many people take notes on the "
@@ -2917,6 +2936,7 @@ msgid "Program Book"
 msgstr "大會手冊"
 
 #: templates/pycontw-2019/_includes/sponsors.html:53
+#: templates/pycontw-2020/_includes/sponsors.html:50
 msgid "Redirect to official website"
 msgstr "導回官方網站"
 
@@ -2974,7 +2994,6 @@ msgid "Lecturer"
 msgstr "講師"
 
 #: templates/pycontw-2019/events/tutorial_list.html:13
-#: templates/pycontw-2020/events/tutorial_list.html:13
 msgid ""
 "Tutorial are events held as part of the main conference, but attendees need "
 "to register separately in order to join. They are either half- or one-day "
@@ -2998,6 +3017,20 @@ msgstr "報名"
 msgid "Warm-Up Session"
 msgstr "暖身活動"
 
+#: templates/pycontw-2020/events/talk_list.html:15
+msgid ""
+"The two conference days are packed with talks about Python by speakers from "
+"Taiwan and around the world. The talks will be either 15- or 30-minute long. "
+"Three tracks of talks will be delivered simultaneously, all with different "
+"topics and difficulties. We suggest you to plan beforehand, and choose what "
+"you want to listen based on your interests. Many people take notes on the "
+"program schedule before the meeting so they don't end up in the wrong place."
+msgstr ""
+"演講為會期兩天最主要的活動，屆時將會有來自台灣各地與全球的講者分享他們在 "
+"Python 相關的發現。Talk 有 15 分鐘與 30 分鐘兩種長度，每天都將有三軌議程同步"
+"進行，配合各個演講的難易度與類型，選擇自己有興趣的主題聆聽。許多人都會事先筆"
+"記想聽的議程，才不會跑錯地點。"
+
 #: templates/pycontw-2020/events/talk_list.html:41
 #, python-format
 msgid " by %(speaker_names)s"
@@ -3020,9 +3053,16 @@ msgstr ""
 "議室，在有特色的咖啡廳、展演空間、甚至是古蹟內來舉辦上述各種主題的演講，讓會"
 "眾能更加舒適地且近距離地與他人互動。"
 
-#: templates/pycontw-2020/index.html:48
-msgid "Call for Proposals"
-msgstr "徵求稿件"
+#: templates/pycontw-2020/events/tutorial_list.html:13
+msgid ""
+"Tutorial are events held as part of the main conference, but attendees need "
+"to register separately in order to join. They are 90-minute events held to "
+"help participants better understand talks during the conference, or get "
+"their hands on more Python applications."
+msgstr ""
+
+"專業課程（Tutotiral）是 PyCon Taiwan 的一部分，只要有購票都有資格參與，但需要另外報名"
+"，以便我們做現場人數控制；專業課程的時間為 90 分鐘。"
 
 #: templates/pycontw-2020/index.html:58
 msgid "Sponsor PyCon TW"
@@ -3234,6 +3274,9 @@ msgstr ""
 #: users/views.py:130
 msgid "Password reset successful. You can now login."
 msgstr "密碼重設成功。您現在即可登入。"
+
+#~ msgid "Call for Proposals"
+#~ msgstr "徵求稿件"
 
 #, fuzzy
 #~| msgid ""

--- a/src/static/pycontw-2020/styles/_box.scss
+++ b/src/static/pycontw-2020/styles/_box.scss
@@ -2,7 +2,7 @@ $box-content-padding-x: 32px;
 $box-content-padding-y: 16px;
 
 .box {
-	$box-border: solid 1px $egyptian-blue;
+	$box-border: solid 1px $brown;
 
 	border: $box-border;
 	border-radius: 5px;
@@ -11,7 +11,7 @@ $box-content-padding-y: 16px;
 	.box-title {
 		margin: 0;
 		padding: (2rem / 3) 1rem;
-		background-color: $egyptian-blue;
+		background-color: $brown;
 		color: $white;
 		line-height: 150%;
 		font-size: 1.25rem;
@@ -23,6 +23,7 @@ $box-content-padding-y: 16px;
 	}
 
 	.box-control {
+		color:$jinger-bread;
 		display: flex;
 		overflow: hidden;
 
@@ -31,10 +32,10 @@ $box-content-padding-y: 16px;
 			@include no-underline();
 
 			flex: 1;
-			border-top: $box-border;
+			border-top: solid 1px $jinger-bread;
 			line-height: 48px;
 			text-align: center;
-			font-weight: 400;
+			font-family: "Philosopher", "Noto Sans TC", "sans-serif";
 		}
 
 		> * + * {
@@ -42,7 +43,7 @@ $box-content-padding-y: 16px;
 		}
 
 		> a:hover {
-			background: $egyptian-blue;
+			background: $brown;
 			color: $white;
 		}
 	}

--- a/src/templates/pycontw-2020/_includes/menu.html
+++ b/src/templates/pycontw-2020/_includes/menu.html
@@ -9,11 +9,9 @@
 {% url 'events_schedule' as events_schedule_url %}
 {% url 'page' path='events/keynotes' as events_keynote_url %}
 {% url 'events_talk_list' as events_talk_list_url %}
-{% url 'events_tutorial_list' as events_tutorial_list_url %}
 {% url 'page' path='events/sprints' as events_sprint_url %}
 {% url 'page' path='events/open-spaces' as events_openspaces_url %}
 {% url 'page' path='events/pyday' as events_pyday_url %}
-{% url 'page' path='events/tutorials' as events_tutorial_url %}
 {% url 'page' path='speaking/cfp' as speaking_cfp_url %}
 {% url 'page' path='speaking/talk' as speaking_talk_url %}
 {% url 'page' path='speaking/tutorial' as speaking_tutorial_url %}
@@ -27,6 +25,7 @@
 {% url 'page' path='portal' as portal_url %}
 {% url 'page' path='sponsor/sponsor' as sponsor_url %}
 {% url 'page' path='events/warmup-session' as warmup_session %}
+{% url 'page' path='events/tutorials' as events_tutorial_list_url %}
 
 <ul class="menu" data-controller="menu">
 	{% with category=request.path|get_path_category %}
@@ -85,8 +84,8 @@
 				<li><a href="{{ events_keynote_url }}">{% trans 'Keynotes' %}</a></li>
 				<!--{% endcomment %}-->
 				<li><a href="{{ events_talk_list_url }}">{% trans 'Talks' %}</a></li>
-				<!--{% comment %}-->
 				<li><a href="{{ events_tutorial_list_url }}">{% trans 'Tutorials' %}</a></li>
+				<!--{% comment %}-->
 				<li><a href="{{ events_openspaces_url }}">{% trans 'Open Spaces' %}</a></li>
 				<!--{% endcomment %}-->
 			</ul>

--- a/src/templates/pycontw-2020/events/tutorial_list.html
+++ b/src/templates/pycontw-2020/events/tutorial_list.html
@@ -10,7 +10,7 @@
 <h1>{% trans 'Tutorials' %}</h1>
 
 <article>
-	<p>{% blocktrans trimmed %}Tutorial are events held as part of the main conference, but attendees need to register separately in order to join. They are either half- or one-day (three or six hours) events held to help participants better understand talks during the conference, or get their hands on more Python applications.{% endblocktrans %}</p>
+	<p>{% blocktrans trimmed %}Tutorial are events held as part of the main conference, but attendees need to register separately in order to join. They are 90-minute events held to help participants better understand talks during the conference, or get their hands on more Python applications.{% endblocktrans %}</p>
 	<p>{% blocktrans trimmed %}<em>Program schedule is subject to change.</em> Please check this page frequently to get the latest version.{% endblocktrans %}</p>
 </article>
 


### PR DESCRIPTION
add pycontw 2020 style scss for tutorials

✅ Closes: close #839

(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)

## Types of changes
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [*] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**
change _box.scss style for pycontw 2020 style

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to '/events/tutorials/'
2. See result

## Expected behavior
Right color for pycontw2020

## Related Issue
#839

![image](https://user-images.githubusercontent.com/14121801/89106067-4f8c6400-d459-11ea-84cb-719b0d32cd22.png)

