### PR TITLE
feat(keynotes): adjust to 2020 style

### DIFF
--- a/src/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/src/locale/zh_Hant/LC_MESSAGES/django.po
@@ -2998,6 +2998,10 @@ msgstr "報名"
 msgid "Warm-Up Session"
 msgstr "暖身活動"
 
+#: templates/pycontw-2020/contents/_default/events/keynotes.html:64
+msgid "To be announced"
+msgstr "即將公佈"
+
 #: templates/pycontw-2020/events/talk_list.html:41
 #, python-format
 msgid " by %(speaker_names)s"

--- a/src/static/pycontw-2020/styles/_palette.scss
+++ b/src/static/pycontw-2020/styles/_palette.scss
@@ -37,6 +37,8 @@ $dark-gray: #262626;
 $imperial: #E23728;
 $salmon-dark: #F6B197;
 $brown: #6A3F3B;
+$my-pink: #D0908A;
+$jazz: #612D2E;
 
 
 /* Some extra styles not in the Zepplin palette. */

--- a/src/static/pycontw-2020/styles/_tabbing.scss
+++ b/src/static/pycontw-2020/styles/_tabbing.scss
@@ -1,5 +1,5 @@
 .tabbing {
-	$background-color: $light-grayish-yellow;
+	$background-color: adjust-color($imperial, $alpha: -0.9);
 
 	&:not(.enabled) {
 		> .tabs {
@@ -11,7 +11,7 @@
 	}
 	&.enabled {
 		> .tabs ~ * {
-			border-top: 2px solid $portica;
+			border-top: 2px solid $my-pink;
 		}
 		.tab-title {
 			display: none;
@@ -37,21 +37,22 @@
 			text-indent: 0;
 			text-align: center;
 			font-weight: normal;
-			color: $light-gray;
+			color: $jazz;
 
 			@include on-desktop() {
 				flex-grow: 0;
 			}
 
 			&.active {
-				background: $portica;
-				color: $egyptian-blue;
+				background: $imperial;
+				color: $white;
 			}
 
 			&:not(.active) {
 				cursor: pointer;
 				&:hover {
-					background: darken($background-color, 5%);
+					background: $imperial;
+					color: $white;
 				}
 			}
 		}

--- a/src/static/pycontw-2020/styles/pages/_keynotes.scss
+++ b/src/static/pycontw-2020/styles/pages/_keynotes.scss
@@ -44,10 +44,10 @@
 			margin-bottom: inherit;
 		}
 		figcaption {
-			color: black;
+			color: $jazz;
 		}
 		.title {
-			color: black;
+			color: $jinger-bread;
 		}
 	}
 }

--- a/src/templates/pycontw-2020/_includes/menu.html
+++ b/src/templates/pycontw-2020/_includes/menu.html
@@ -81,9 +81,7 @@
 		<div class="dropdown">
 			<ul class="submenu">
 				<li><a href="{{ warmup_session }}">{% trans 'Warm-Up Session' %}</a></li>
-				<!--{% comment %}-->
 				<li><a href="{{ events_keynote_url }}">{% trans 'Keynotes' %}</a></li>
-				<!--{% endcomment %}-->
 				<li><a href="{{ events_talk_list_url }}">{% trans 'Talks' %}</a></li>
 				<!--{% comment %}-->
 				<li><a href="{{ events_tutorial_list_url }}">{% trans 'Tutorials' %}</a></li>

--- a/src/templates/pycontw-2020/contents/_default/events/keynotes.html
+++ b/src/templates/pycontw-2020/contents/_default/events/keynotes.html
@@ -54,13 +54,16 @@
 					{{ data.speaker.bio|linebreaks }}
 				<div class="social">
 					{% for key, url in data.social.items %}
+					{% if url %}
 					<a href="{{ url }}" target="_blank" rel="noopener"><span class="fa fa-{{ key }}"></span></a>
+					{% endif %}
 					{% endfor %}
 				</div>
 			</article>
 			<article data-target="tabbing.pane">
+				{% trans "To be announced" as placeholder_description %}
 				<h3 class="tab-title">{% trans 'Speech' %}</h3>
-				{{ data.session.description|linebreaks }}
+				{{ data.session.description|default:placeholder_description|linebreaks }}
 			</article>
 			{% if data.slido %}
 			<article data-target="tabbing.pane">


### PR DESCRIPTION
## Types of changes
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [x] **Other (page style)**

## Description
Adjusting keynotes page to 2020 style

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to the `/events/keynotes/` URL

## Expected behavior
You should see the keynotes page with style aligning with those mentioned is #838.

## Related Issue
#838 

## More Information
**Screenshots**
![image](https://user-images.githubusercontent.com/6041291/89453134-55ec4a00-d791-11ea-94f2-3353eaa14fb9.png)

**Additional context**
None