### PR TITLE
feat(sprints): add menu link

### DIFF
--- a/src/templates/pycontw-2020/_includes/menu.html
+++ b/src/templates/pycontw-2020/_includes/menu.html
@@ -89,6 +89,7 @@
 				<li><a href="{{ events_keynote_url }}">{% trans 'Keynotes' %}</a></li>
 				<li><a href="{{ events_talk_list_url }}">{% trans 'Talks' %}</a></li>
 				<li><a href="{{ events_tutorial_list_url }}">{% trans 'Tutorials' %}</a></li>
+				<li><a href="{{ events_sprint_url }}">{% trans 'Sprints' %}</a></li>
 				<!--{% comment %}-->
 				<li><a href="{{ events_openspaces_url }}">{% trans 'Open Spaces' %}</a></li>
 				<!--{% endcomment %}-->


### PR DESCRIPTION
(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)

## Types of changes
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [x] **Other (page content)**

## Description
Add a link to `/events/sprints` in the menu

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Hover over the events menu in the front page

## Expected behavior
Link to the Sprints page is within the events menu

## Related Issue
Implemented as per @yychen's [comment](https://github.com/pycontw/pycon.tw/pull/863#pullrequestreview-463708865) 

## More Information
**Screenshots**
![image](https://user-images.githubusercontent.com/6041291/89712961-db0c7480-d9c6-11ea-93ba-069977934bda.png)
