### PR TITLE
chore(ccip): add 2020 sponsor/staff templates for CCIP

### DIFF
--- a/src/templates/pycontw-2020/ccip/sponsors.html
+++ b/src/templates/pycontw-2020/ccip/sponsors.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+
+{% load i18n static %}
+
+{% block styles %}
+<link rel="stylesheet" type="text/x-scss" href="{% static 'pycontw-2020/styles/ccip.scss' %}">
+{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono:100i">
+{% endblock extra_css %}
+
+{% block titletag %}
+<title>PyCon Taiwan 2020</title>
+{% endblock titletag %}
+
+{% block nav %}{% endblock nav %}
+
+{% block content_full %}
+{% language 'en-us' %}
+{% include '_includes/sponsors.html' %}
+{% endlanguage %}
+{% endblock content_full %}
+
+{% block footer %}
+<footer></footer>
+{% endblock footer %}

--- a/src/templates/pycontw-2020/ccip/staff.html
+++ b/src/templates/pycontw-2020/ccip/staff.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block styles %}
+{{ block.super }}
+<link rel="stylesheet" type="text/x-scss" href="{% static 'pycontw-2020/styles/ccip.scss' %}">
+{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono:100i">
+{% endblock extra_css %}
+
+{% block titletag %}
+<title>PyCon Taiwan 2020</title>
+{% endblock titletag %}
+
+{% block nav %}{% endblock nav %}
+
+{% block content_full %}
+{% include '_includes/staff.html' %}
+{% endblock content_full %}
+
+{% block footer %}
+<footer></footer>
+{% endblock footer %}
+
+


### PR DESCRIPTION
- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
Copy the 2019 CCIP templates to 2020 folder.

## Steps to Test This Pull Request

Go to following URLs:
- <host>/ccip/staff/
- <host>/ccip/sponsors/

## Expected behavior
Should see the content-only view (no header, nav, or footer) for staff & sponsor page 

## Related Issue
#877 

## More Information

2019 version as reference:
- https://tw.pycon.org/2019/ccip/staff/
- https://tw.pycon.org/2019/ccip/sponsors/
