### PR TITLE
feat: 🎸 already implement this issue request

### DIFF
--- a/src/templates/pycontw-2020/events/sponsored_event_detail.html
+++ b/src/templates/pycontw-2020/events/sponsored_event_detail.html
@@ -1,0 +1,2 @@
+{% extends 'events/talk_detail.html' %}
+{# Exists for possible future implementation. #}

--- a/src/templates/pycontw-2020/events/talk_list.html
+++ b/src/templates/pycontw-2020/events/talk_list.html
@@ -52,6 +52,17 @@
 
 {% endfor %}
 
+{% if sponsored_events %}
+<h3>{% trans 'Invited Events' %}</h3>
+<article>
+	<ul class="talk-list">
+		{% for event in sponsored_events %}
+		<li><p>{% blocktrans with event_title=event.title host_name=event.host.speaker_name sponsored_event_url=event.get_absolute_url %}<a class="proposal-title" href="{{ sponsored_event_url }}">{{ event_title }}</a> by {{ host_name }}{% endblocktrans %}</p></li>
+		{% endfor %}
+	</ul>
+</article>
+{% endif %}
+
 <section class="note">
 	<a name="community-track"></a>
 	<span class="talk-label"><a href="{{ community_track_url }}">{% trans 'Community Track' %}</a></span>

--- a/src/templates/pycontw-2020/events/talk_list.html
+++ b/src/templates/pycontw-2020/events/talk_list.html
@@ -53,11 +53,18 @@
 {% endfor %}
 
 {% if sponsored_events %}
-<h3>{% trans 'Invited Events' %}</h3>
 <article>
+	<h3>{% trans 'Invited Events' %}</h3>
 	<ul class="talk-list">
 		{% for event in sponsored_events %}
-		<li><p>{% blocktrans with event_title=event.title host_name=event.host.speaker_name sponsored_event_url=event.get_absolute_url %}<a class="proposal-title" href="{{ sponsored_event_url }}">{{ event_title }}</a> by {{ host_name }}{% endblocktrans %}</p></li>
+		<li>
+			<p>
+				{% with event_title=event.title host_name=event.host.speaker_name sponsored_event_url=event.get_absolute_url %}
+				<a class="proposal-title" href="{{ sponsored_event_url }}">{{ event_title }}</a>
+				{% blocktrans %} by {{ host_name }}{% endblocktrans %}
+				{% endwith %}
+			</p>
+		</li>
 		{% endfor %}
 	</ul>
 </article>

--- a/src/templates/pycontw-2020/events/talk_list.html
+++ b/src/templates/pycontw-2020/events/talk_list.html
@@ -60,7 +60,7 @@
 		<li>
 			<p>
 				{% with event_title=event.title host_name=event.host.speaker_name sponsored_event_url=event.get_absolute_url %}
-				<a class="proposal-title" href="{{ sponsored_event_url }}">{{ event_title }}</a>
+				<a class="talk-title" href="{{ sponsored_event_url }}">{{ event_title }}</a>
 				{% blocktrans %} by {{ host_name }}{% endblocktrans %}
 				{% endwith %}
 			</p>


### PR DESCRIPTION
sponsored talks go back in talk list!

✅ Closes: #865

(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)

## Types of changes
Please put an `x` in the box that applies

- [ * ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**
let show sponsored lists in  talk list

## Steps to Test This Pull Request
Steps to reproduce the behavior:
The sponsored lists don't show in  talk list

## Expected behavior
We can see the sponsored list in talk list

## Related Issue
#865 

## More Information
![image](https://user-images.githubusercontent.com/14121801/90961203-c3121600-e4d9-11ea-8cec-a07ae90d0833.png)
![image](https://user-images.githubusercontent.com/14121801/90961206-c7d6ca00-e4d9-11ea-90dd-96e290c18b5a.png)

