### PR TITLE
Change the live room name

### DIFF
--- a/src/ext2020/views.py
+++ b/src/ext2020/views.py
@@ -34,9 +34,9 @@ def live(request):
         attendee = Attendee.objects.create(token=token)
 
     rooms = OrderedDict()
-    rooms['R0'] = reg.get(f'{settings.CONFERENCE_DEFAULT_SLUG}.live.r0', '')
     rooms['R1'] = reg.get(f'{settings.CONFERENCE_DEFAULT_SLUG}.live.r1', '')
     rooms['R2'] = reg.get(f'{settings.CONFERENCE_DEFAULT_SLUG}.live.r2', '')
+    rooms['R3'] = reg.get(f'{settings.CONFERENCE_DEFAULT_SLUG}.live.r3', '')
 
     return render(request, 'ext/live.html', {
         'attendee': attendee,


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
The main conference rooms are R1, R2, R3 instead of R0, R1, R2.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to localhost:8000/admin/ext2020/attendee/ and add an attendee with 32-char token and verified set to true
2. Go to localhost:8000/ext/live?token={TOKEN} (where {TOKEN} is the token you just generated)
3. You should see the rooms are 1, 2, 3, instead of 0, 1, 2.

**Additional context**
If you want to test the youtube, you can go to Django Registry ( localhost:8000/admin/registry/entry ) and add a record, where key is `pycontw-2020.live.r1` and the value is the youtube id.