### PR TITLE
Fix ext2020 trailing slash problem

### DIFF
--- a/src/ext2020/urls.py
+++ b/src/ext2020/urls.py
@@ -3,6 +3,6 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^live$', views.live, name='live'),
-    url(r'^discord$', views.discord, name='discord'),
+    url(r'^live/$', views.live, name='live'),
+    url(r'^discord/$', views.discord, name='discord'),
 ]


### PR DESCRIPTION
## Types of changes
Please put an `x` in the box that applies

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
Make both `ext/discord` and `ext/discord/` work (also applies to `ext/live`)

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to localhost:8000/ext/discord/
2. See 404

## Expected behavior
It should show the discord page.