### PR TITLE
Fix keynote wrong link in the main schedule

### DIFF
--- a/src/templates/pycontw-2020/events/_includes/schedule_keynote_event.html
+++ b/src/templates/pycontw-2020/events/_includes/schedule_keynote_event.html
@@ -1,7 +1,7 @@
 {% load events %}
 
 {% with data=event.get_static_data_for_locale %}
-	<a href="{% url 'page' path='events/keynotes' %}#{{ event.slug }}" class="keynote-event localed-url">
+	<a href="{% url 'page' path='conference/keynotes' %}#{{ event.slug }}" class="keynote-event localed-url">
 		<div class="context-container">
 			<div class="room">
 				<div class="room-tag room-{{ event.location }}"></div>


### PR DESCRIPTION
## Types of changes
- [X] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**
We've changed the keynote path from events to conference. The schedule renderer path needs an update.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to localhost:8000/conference/schedule/new
2. Check on any keynote event link
3. It leads to the wrong URL

## Expected behavior
It should be the correct URL, which is '/conference/keynotes'

## Related Issue
#909 

## More Information
**Additional context**
It's weird that if you click on, say "wenyu-su"'s keynote link, it doesn't jump to the specific section. Need to check this as well.
After the fix is applied, re-generate schedule is required.
Go to '/2020/conference/schedule/new' and generate a new one on the production site.