### PR TITLE
chore(discord): update invite link

### DIFF
--- a/src/locale/en_US/LC_MESSAGES/django.po
+++ b/src/locale/en_US/LC_MESSAGES/django.po
@@ -3612,13 +3612,13 @@ msgstr ""
 #: templates/pycontw-2020/_includes/ext/discord.html:123
 msgid ""
 "3.Join the Python Taiwan Discord server. <br>Python Taiwan Discord server "
-"invite link: <a href='https://discord.gg/YYAgUk7'>https://discord.gg/"
-"YYAgUk7</a> <br>In your Discord client App, click the button with plus sign, "
+"invite link: <a href='https://discord.gg/94hgCQv'>https://discord.gg/"
+"94hgCQv</a> <br>In your Discord client App, click the button with plus sign, "
 "and then select 'Join a server'."
 msgstr ""
 "3.Join the Python Taiwan Discord server. <br>Python Taiwan Discord server "
-"invite link: <a href='https://discord.gg/YYAgUk7'>https://discord.gg/"
-"YYAgUk7</a> <br>In your Discord client App, click the button with plus sign, "
+"invite link: <a href='https://discord.gg/94hgCQv'>https://discord.gg/"
+"94hgCQv</a> <br>In your Discord client App, click the button with plus sign, "
 "and then select 'Join a server'."
 
 #: templates/pycontw-2020/_includes/ext/discord.html:126

--- a/src/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/src/locale/zh_Hant/LC_MESSAGES/django.po
@@ -3509,12 +3509,12 @@ msgstr ""
 #: templates/pycontw-2020/_includes/ext/discord.html:123
 msgid ""
 "3.Join the Python Taiwan Discord server. <br>Python Taiwan Discord server "
-"invite link: <a href='https://discord.gg/YYAgUk7'>https://discord.gg/"
-"YYAgUk7</a> <br>In your Discord client App, click the button with plus sign, "
+"invite link: <a href='https://discord.gg/94hgCQv'>https://discord.gg/"
+"94hgCQv</a> <br>In your Discord client App, click the button with plus sign, "
 "and then select 'Join a server'."
 msgstr ""
 "3. 加入 Python Taiwan 的 Discord 伺服器. <br>Python Taiwan 伺服器 邀請連結: "
-"<a href='https://discord.gg/YYAgUk7'>https://discord.gg/YYAgUk7</a> <br>在您"
+"<a href='https://discord.gg/94hgCQv'>https://discord.gg/94hgCQv</a> <br>在您"
 "的 Discord 程式中，按下左邊的 '+' 號按鈕，並選擇 '加入伺服器'。"
 
 #: templates/pycontw-2020/_includes/ext/discord.html:126

--- a/src/templates/pycontw-2020/_includes/ext/discord.html
+++ b/src/templates/pycontw-2020/_includes/ext/discord.html
@@ -120,7 +120,7 @@
   <p>{% trans "2.Register an account on Discord if you don’t have one. Open the Discord client you just installed. Click the 'Register' link below and complete your registration. (You may be asked to verify your account with the verification mail that Discord sends you)" %}</p>
   <a href="{% static 'pycontw-2020/assets/discord-0.jpg' %}"><img src="{% static 'pycontw-2020/assets/discord-0.jpg' %}" alt=""></a>
 
-  <p>{% trans "3.Join the Python Taiwan Discord server. <br>Python Taiwan Discord server invite link: <a href='https://discord.gg/YYAgUk7'>https://discord.gg/YYAgUk7</a> <br>In your Discord client App, click the button with plus sign, and then select 'Join a server'." %}</p>
+  <p>{% trans "3.Join the Python Taiwan Discord server. <br>Python Taiwan Discord server invite link: <a href='https://discord.gg/94hgCQv'>https://discord.gg/94hgCQv</a> <br>In your Discord client App, click the button with plus sign, and then select 'Join a server'." %}</p>
   <a href="{% static 'pycontw-2020/assets/discord-1.png' %}"><img src="{% static 'pycontw-2020/assets/discord-1.png' %}" alt=""></a>
 
   <p>{% trans "In this dialog, copy the invite link above and paste it to the inputbox, then click 'Join'." %}</p>


### PR DESCRIPTION
## Types of changes

- [ ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [x] **Other (chore)**

## Description
The invitation link needs to be updated. 

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to `<host>/<lang>/ext/discord/`
2. Click on the invite link
3. See the current one is expired
![image](https://user-images.githubusercontent.com/24987826/91656280-28719280-eaea-11ea-8480-60e4e413cd1f.png)

## Expected behavior
The invite link should work
![image](https://user-images.githubusercontent.com/24987826/91656373-d11ff200-eaea-11ea-98a8-e17ac59aec1c.png)


## Related Issue
No issue is related. This request is from the program team.
