### PR TITLE
fix(schedule): keynote id in the link is incorrect

### DIFF
--- a/src/templates/pycontw-2020/events/_includes/schedule_keynote_event.html
+++ b/src/templates/pycontw-2020/events/_includes/schedule_keynote_event.html
@@ -1,7 +1,7 @@
 {% load events %}
 
 {% with data=event.get_static_data_for_locale %}
-	<a href="{% url 'page' path='conference/keynotes' %}#{{ event.slug }}" class="keynote-event localed-url">
+	<a href="{% url 'page' path='conference/keynotes' %}#keynote-speaker-{{ event.slug }}" class="keynote-event localed-url">
 		<div class="context-container">
 			<div class="room">
 				<div class="room-tag room-{{ event.location }}"></div>


### PR DESCRIPTION
## Types of changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
The links to keynote on the schedule page are correct but do not lead to the correct session. Take Marriata's session as an example, the link is `https://tw.pycon.org/2020/zh-hant/conference/keynotes/#mariatta-wijaya` but it does not jump to the correct session. The root cause is the id of the keynote session is now `keynote-speaker-{{slug}}` (see [here](https://github.com/pycontw/pycon.tw/blob/master/src/templates/pycontw-2020/contents/_default/conference/keynotes.html#L33)).

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to the schedule page and click on the keynote event 

## Expected behavior
It should lead the user to the target session on the keynote page 

## Related Issue
#910 
