### PR TITLE
fix(community-track): also display choice count in topic session

### DIFF
--- a/src/templates/pycontw-2020/events/_includes/community-track-overview.html
+++ b/src/templates/pycontw-2020/events/_includes/community-track-overview.html
@@ -24,7 +24,6 @@
 			<div class="venue-name">
 				{{ venue.name }}
 				<span class="stats">
-
 					<span
 						{% if venue.get_choice_count >= venue.get_soft_limit and venue.get_choice_count <= venue.capacity %}
 							class="text-yellow"
@@ -32,6 +31,7 @@
 							class="text-danger"
 						{% endif %}
 						> {{ venue.get_choice_count }} </span> / <span>{{ venue.capacity }}</span>
+				</span>
 			</div>
 		</div>
 	{% endfor %}

--- a/src/templates/pycontw-2020/events/_includes/community-track.html
+++ b/src/templates/pycontw-2020/events/_includes/community-track.html
@@ -28,7 +28,13 @@
 		{{ venue.name }}
 
 		<span class="stats">
-			/{{ venue.capacity }}
+            <span
+                {% if venue.get_choice_count >= venue.get_soft_limit and venue.get_choice_count <= venue.capacity %}
+                    class="text-yellow"
+                {% elif venue.get_choice_count > venue.capacity %}
+                    class="text-danger"
+                {% endif %}
+                > {{ venue.get_choice_count }} </span> / <span>{{ venue.capacity }}</span>
 		</span>
         <br />
 


### PR DESCRIPTION
## Types of changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
In #905, the choice count of each venue is shown in the overview section:
![image](https://user-images.githubusercontent.com/24987826/91666493-bfad0900-eb2f-11ea-8d4f-6bdc73879f4c.png)

However, it's not displayed in the topic & venue section:
![image](https://user-images.githubusercontent.com/24987826/91666490-b754ce00-eb2f-11ea-9eff-482d0c5b4fab.png)


## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to `<host>/<lang>/conference/community-track/`

## Expected behavior
Should see the choice count in both the overview section & the topic section.

## Related Issue
#879 #905 

