### PR TITLE
fix cover image size

### DIFF
--- a/src/static/pycontw-2020/styles/pages/_job-listings.scss
+++ b/src/static/pycontw-2020/styles/pages/_job-listings.scss
@@ -3,7 +3,8 @@
 		> header {
 			> figure {
 				img {
-					width: unset;
+					width: 100%;
+					height: unset;
 					border-radius: unset;
 				}
 			}


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
the original image size is wrong on mobile
<img width="568" alt="Screen Shot 2020-08-31 at 11 23 28 PM" src="https://user-images.githubusercontent.com/50104002/91737711-04917800-ebe2-11ea-8215-fa4467ed8608.png">

## Expected behavior
<img width="498" alt="Screen Shot 2020-08-31 at 11 23 15 PM" src="https://user-images.githubusercontent.com/50104002/91737719-06f3d200-ebe2-11ea-8367-7af1c158c5ac.png">

## Related Issue
If applicable, refernce to the issue related to this pull request.

## More Information
**Screenshots**
If applicable, add screenshots to help explain your problem.

**Additional context**
Add any other context about the problem here. You may also want to refer
to [how to wirte the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)
