### PR TITLE
fix(schedule): Fix styles

### DIFF
--- a/src/static/pycontw-2020/styles/pages/_events.scss
+++ b/src/static/pycontw-2020/styles/pages/_events.scss
@@ -387,7 +387,7 @@ main {
 					position: sticky;
 					position: -webkit-sticky;
 					top: 0;
-					z-index: 1000;
+					z-index: 10;
 					padding: 16px 0;
 					background: $brick;
 

--- a/src/static/pycontw-2020/styles/pages/_events.scss
+++ b/src/static/pycontw-2020/styles/pages/_events.scss
@@ -171,11 +171,11 @@ $icon-height: 26px;
 
 		.title {
 			display: -webkit-box;
-			height: 90px;
 			overflow: hidden;
+			line-height: 1.2em;
 			text-overflow: ellipsis;
 			box-sizing: border-box;
-			-webkit-line-clamp: 4;
+			-webkit-line-clamp: 3;
 		}
 
 		.tags {


### PR DESCRIPTION
## Types of changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
- Fix the styling issues mentioned in #907 and #922

## Steps to Test This Pull Request
Steps to reproduce the behavior:

#### #907
1. Go to `/events/schedule`
1. Scroll to an event that has long title
1. Toggle the browser viewport and see if the texts are not cropped off

#### #922
1. Go to `/events/schedule`
1. Adjust the browser to a mobile viewport breakpoint
1. Click on the menu icon and see if the display mentioned in the issue has gone

## Expected behavior
- In mobile view, at `/events/schedule` route, the menu shouldn't contain the schedule time headers
- There shouldn't be cropped texts in event titles among different viewports

## Related Issue
- #907
- #922

## More Information
