### PR TITLE
fix(tutorial-detail): hack for stopping 500s

### DIFF
--- a/src/events/views.py
+++ b/src/events/views.py
@@ -265,14 +265,16 @@ class ProposedEventMixin:
 
     def get_context_data(self, **kwargs):
         community_track_event = None
-        try:
-            community_track_event = (
-                CommunityTrackEvent.objects
-                                .select_related('begin_time', 'end_time')
-                                .get(talk=self.object)
-            )
-        except (CommunityTrackEvent.DoesNotExist, ValueError):
-            pass
+
+        if type(self.object) is TalkProposal:
+            try:
+                community_track_event = (
+                    CommunityTrackEvent.objects
+                                    .select_related('begin_time', 'end_time')
+                                    .get(talk=self.object)
+                )
+            except CommunityTrackEvent.DoesNotExist:
+                pass
 
         return super().get_context_data(
             community_track_event=community_track_event,

--- a/src/events/views.py
+++ b/src/events/views.py
@@ -271,7 +271,7 @@ class ProposedEventMixin:
                                 .select_related('begin_time', 'end_time')
                                 .get(talk=self.object)
             )
-        except CommunityTrackEvent.DoesNotExist:
+        except (CommunityTrackEvent.DoesNotExist, ValueError):
             pass
 
         return super().get_context_data(


### PR DESCRIPTION
## Types of changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
Unhandled error when trying to access tutorial details.

Part of the debug info:
![image](https://user-images.githubusercontent.com/24987826/92151350-8f2cde00-ee53-11ea-8c10-e6368a4049db.png)


## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to `<host>/<lang>/conference/tutorials/`
2. Click on any button below the description of each tutorial

## Expected behavior
Should display the page successfully

## Related Issue
#928 

## More Information

Currently not fully understand all code for the tutorial detail page. Just do the hack for preventing the 500s and will try to do it in a better way later