### PR TITLE
fix(sponsoredEvent): fix cannot display location issue

### DIFF
--- a/src/events/views.py
+++ b/src/events/views.py
@@ -307,6 +307,21 @@ class SponsoredEventDetailView(EventInfoMixin, DetailView):
     def get_time_slot(self):
         return (self.object.begin_time.value, self.object.end_time.value)
 
+    def get_context_data(self, **kwargs):
+        community_track_event = None
+        try:
+            community_track_event = (
+                CommunityTrackEvent.objects
+                .select_related('begin_time', 'end_time')
+                .get(sponsored_event=self.object)
+            )
+        except CommunityTrackEvent.DoesNotExist:
+            pass
+
+        return super().get_context_data(
+            community_track_event=community_track_event,
+            **kwargs,
+        )
 
 class TutorialDetailView(
     AcceptedProposalMixin, ProposedEventMixin,

--- a/src/templates/pycontw-2020/events/talk_detail.html
+++ b/src/templates/pycontw-2020/events/talk_detail.html
@@ -15,16 +15,7 @@
 
 <section class="content info">
 	<ul>
-		{% if event %}
-		<li>
-			<dfn class="location"></dfn>
-			<span>{{ event.get_location_display|default:event.location }}</span>
-		</li>
-		<li>
-			<dfn class="slot"></dfn>
-			<span>{% blocktrans with date_display=event|event_date_display begin_time_display=event.begin_time.value|date:'H:i' end_time_display=event.end_time.value|date:'H:i' %}{{ date_display }}, {{ begin_time_display }}&#8209;{{ end_time_display }}{% endblocktrans %}</span>
-		</li>
-        {% elif community_track_event %}
+        {% if community_track_event %}
         {% with event=community_track_event %}
 		<li>
 			<dfn class="location"></dfn>
@@ -35,6 +26,15 @@
 			<span>{% blocktrans with date_display=event|event_date_display begin_time_display=event.begin_time.value|date:'H:i' end_time_display=event.end_time.value|date:'H:i' %}{{ date_display }}, {{ begin_time_display }}&#8209;{{ end_time_display }}{% endblocktrans %}</span>
 		</li>
         {% endwith %}
+		{% elif event %}
+		<li>
+			<dfn class="location"></dfn>
+			<span>{{ event.get_location_display|default:event.location }}</span>
+		</li>
+		<li>
+			<dfn class="slot"></dfn>
+			<span>{% blocktrans with date_display=event|event_date_display begin_time_display=event.begin_time.value|date:'H:i' end_time_display=event.end_time.value|date:'H:i' %}{{ date_display }}, {{ begin_time_display }}&#8209;{{ end_time_display }}{% endblocktrans %}</span>
+		</li>
 		{% endif %}
 		<li>
 			<dfn class="category">{% trans 'Category: ' %}</dfn>


### PR DESCRIPTION
## Types of changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
[This talk](https://tw.pycon.org/2020/zh-hant/conference/talk/sponsored/practical-enterprise-jupyterhub-deployment-and-mlo/) is the only sponsored event and also one of the talks in the community track. However, the location on the detail page cannot be derived successfully and is shown as `Other`.

![image](https://user-images.githubusercontent.com/24987826/92180098-cbbf0080-ee78-11ea-9cb8-01065957fb39.png)

The solution is simply to insert the sponsored event into context data (similar to what've done in `ProposedEventMixin`).

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to `<host>/<lang>/conference/talk/sponsored/practical-enterprise-jupyterhub-deployment-and-mlo/`

## Expected behavior
The correct location should be shown as below:
![image](https://user-images.githubusercontent.com/24987826/92180369-6ddee880-ee79-11ea-8451-c6b124b1c91c.png)


## Related Issue
N/A

