### PR TITLE
Load 600 and 700 font

### DIFF
--- a/src/templates/pycontw-2020/base.html
+++ b/src/templates/pycontw-2020/base.html
@@ -28,7 +28,7 @@
 {% endblock meta_og %}
 
 <link rel="stylesheet" href="https://fonts.googleapis.com/earlyaccess/notosanstc.css">
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Quicksand:300,400|Raleway:300,400|Philosopher|Quicksand&display=swap">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Quicksand:300,400,600,700|Raleway:300,400|Philosopher|Quicksand&display=swap">
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css">
 
 {% compress css %}


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [X] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**
Load the missing weights of the font "Quicksand".

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to localhost:8000/conference/schedule on a Windows box
2. The fonts look weird

## Expected behavior
It should look nice.

## Related Issue
#907 

## More Information
**Screenshots**
Original:
![圖片](https://user-images.githubusercontent.com/484883/92194243-c673ad00-ee9c-11ea-85e1-843b6ffd389a.png)

After loading the weights:
![圖片](https://user-images.githubusercontent.com/484883/92194325-f91da580-ee9c-11ea-8cb8-c0b94230b58e.png)