### PR TITLE
Make the remote tag more readable in schedule table

### DIFF
--- a/src/static/pycontw-2020/styles/pages/_events.scss
+++ b/src/static/pycontw-2020/styles/pages/_events.scss
@@ -82,17 +82,22 @@ $icon-height: 26px;
 				margin-bottom: 8px;
 				font-size: 18px;
 				font-weight: 700;
-
-				.remote-label {
-					font-size: 0.5rem;
-					color: white;
-					background-color: $jinger-bread;
-				
-					padding: 0.8px 3.5px;
-					border-radius: 3px;
-					position: relative;
-				}
 			}
+
+            .remote-block {
+                margin-top: -8px;
+                margin-bottom: 8px;
+
+                .remote-label {
+                    font-size: 0.8rem;
+                    color: white;
+                    background-color: $jinger-bread;
+
+                    padding: 0.8px 3.5px;
+                    border-radius: 3px;
+                    position: relative;
+                }
+            }
 
 			.speaker {
 				margin-bottom: 8px;

--- a/src/templates/pycontw-2020/events/_includes/schedule_talk_event.html
+++ b/src/templates/pycontw-2020/events/_includes/schedule_talk_event.html
@@ -12,12 +12,14 @@
 			     title="{{ info.title }}"
 			>
 				{{ info.title }}
-				{% if is_remote %}
-				<span class="remote-label">
-					Remote Talk
-				</span>
-				{% endif %}
 			</div>
+            {% if is_remote %}
+            <div class="remote-block">
+                <span class="remote-label">
+                    Remote Talk
+                </span>
+            </div>
+            {% endif %}
 			<div class="speaker">by <span class="name">{{ speakers }}</span></div>
 			<div class="tags">
 				<div class="language-{{ info.language.lower }}"></div>


### PR DESCRIPTION
## Types of changes
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [ ] **New feature**
- [X] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**
Make the remote talk tag in the schedule table larger and more readable.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to localhost:8000/conference/schedule
2. The remote talk tag is too small

## Expected behavior
Should be larger, readable and does not split into two lines or being cut out.

## Related Issue
If applicable, refernce to the issue related to this pull request.

## More Information
**Screenshots**
Before:
<img width="250" alt="圖片" src="https://user-images.githubusercontent.com/484883/92263731-b0eb9b00-ef0f-11ea-81b7-7ea57ead2fbe.png">

After:
<img width="219" alt="圖片" src="https://user-images.githubusercontent.com/484883/92263746-b6e17c00-ef0f-11ea-94b7-a6cf2991f04c.png">


**Additional context**
Add any other context about the problem here. You may also want to refer
to [how to wirte the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)
