### PR TITLE
chore(covid-19-policy): add health declaration form link

### DIFF
--- a/src/templates/pycontw-2020/contents/en/covid-19/guidelines.html
+++ b/src/templates/pycontw-2020/contents/en/covid-19/guidelines.html
@@ -25,10 +25,10 @@
 
 <ol class="custom_ol">
 	<li>
-		<b>Every PyCon TW attendee has to fill out the PyCon TW 2020 Personal Health Declaration Form online</b>, a
-		personal QR code will be generated after you complete the form. Your QR code is your entry to PyCon TW 2020, it is
-		not retrievable after it is lost. If you lose your QR code, you will need to fill out the Health Declaration Form
-		again to obtain a new one.
+		<b>Every PyCon TW attendee has to fill out the <a href="https://cdc.pycon.tw/" target="_blank" rel="noopener">PyCon
+		TW 2020 Personal Health Declaration Form</a> online</b>, a personal QR code will be generated after you complete the
+		form. Your QR code is your entry to PyCon TW 2020, it is not retrievable after it is lost. If you lose your QR code,
+		you will need to fill out the Health Declaration Form again to obtain a new one.
 		<ol class="custom_ol">
 			<li type="a">
 				PyCon TW 2020 Health Declaration Form will be available online for previewing on August 20 and be ready

--- a/src/templates/pycontw-2020/contents/zh/covid-19/guidelines.html
+++ b/src/templates/pycontw-2020/contents/zh/covid-19/guidelines.html
@@ -20,8 +20,9 @@
 
 <ol class="custom_ol">
 	<li>
-		<b>每一位與會者須線上填寫「PyCon TW 2020 個人健康聲明書 」</b>(以下簡稱「個人健康申明書」)，填寫完畢個人健康聲明書可獲得專屬入場的 QR Code 與即能參與 PyCon TW 實體活動，該 QR Code
-		請務必妥善保管，因資料僅供儲存用，遺失將無法取回，僅能再度填寫個人健康聲明書領取新的 QR Code。
+		<b>每一位與會者須線上填寫「<a href="https://cdc.pycon.tw/" target="_blank" rel="noopener">PyCon TW 2020 個人健康聲明書</a>」</b>
+		(以下簡稱「個人健康申明書」)，填寫完畢個人健康聲明書可獲得專屬入場的 QR Code 與即能參與 PyCon TW 實體活動，該 QR Code 請務必妥善保管，因資料僅供儲存用，
+		遺失將無法取回，僅能再度填寫個人健康聲明書領取新的 QR Code。
 		<ul class="custom_ul">
 			<li>
 				PyCon TW 2020 個人健康聲明書預計於 <b>2020 年 08 月20 日開放檢視</b>，並於 <b>2020 年 08 月 30 日開放填寫</b>。


### PR DESCRIPTION
## Types of changes

- [ ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [x] **Other (add link)**

## Description
Add the health declaration link on the COVID-19 guidelines page. It could possibly accelerate the registration process.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to `<host>/<lang>/covid-19/guidelines/`

## Expected behavior
The viewers should be able to link the form

## Related Issue
N/A

