### PR TITLE
Add traffic info into OPass community track page

### DIFF
--- a/src/templates/pycontw-2020/ccip/community_track.html
+++ b/src/templates/pycontw-2020/ccip/community_track.html
@@ -24,49 +24,8 @@
     <h2>{% trans 'Topics &amp; Venues' %}</h2>
     {% include 'events/_includes/community-track.html' %}
 
-    <h2>{% trans 'Agenda' %}</h2>
-    <table>
-        <thead>
-        <tr>
-            <th>{% trans 'Time' %}</th>
-            <th>{% trans 'Event' %}</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-            <td>13:40 - 13:50</td>
-            <td>{% trans 'Community Introduction' %}</td>
-        </tr>
-        <tr>
-            <td>13:50 - 14:20</td>
-            <td>{% trans 'Talk' %}</td>
-        </tr>
-        <tr>
-            <td>14:20 - 14:30</td>
-            <td>{% trans 'Break' %}</td>
-        </tr>
-        <tr>
-            <td>14:30 - 15:00</td>
-            <td>{% trans 'Talk' %}</td>
-        </tr>
-        <tr>
-            <td>15:00 - 15:10</td>
-            <td>{% trans 'Break' %}</td>
-        </tr>
-        <tr>
-            <td>15:10 - 15:50</td>
-            <td>{% trans 'Talk / Sponsor Introduction' %}</td>
-        </tr>
-        <tr>
-            <td>15:50 - 16:00</td>
-            <td>{% trans 'Break' %}</td>
-        </tr>
-        <tr>
-            <td>16:00 - 16:40</td>
-            <td>{% trans 'Free Sharing' %}</td>
-        </tr>
-        </tbody>
-    </table>
+    <h2>{% trans 'traffic' %}</h2>                                             
+    {% include 'events/_includes/community-track-traffic.html' %}
 </main>
 {% endblock content_full %}
 

--- a/src/templates/pycontw-2020/events/_includes/community-track-traffic.html
+++ b/src/templates/pycontw-2020/events/_includes/community-track-traffic.html
@@ -1,0 +1,49 @@
+{% load i18n static %}
+<p>‼請注意，9/06下午的社群議程場地會由成大移動到各社群議程場地哦
+    為了大家的方便，今年大會安排了交通接駁車方便大家移動到各場地
+    從外縣市來到台南的朋友們可以不必擔心了～
+</p>
+
+<table class="table">
+    <thead>
+    <tr>
+        <th>{% trans 'Time' %}</th>
+        <th style="width: 70%">{% trans 'Shuttle bus route' %}</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>12:20</td>
+        <td >
+            <p>[Car 1] {% trans 'Cheng Kung University' %} -> {% trans 'Tainan Cultural and Creative Park' %}</p>
+            <p>[Car 2] {% trans 'Cheng Kung University' %} -> {% trans 'Tsang Fong Art Space' %}</p>
+            <p>[Car 3] {% trans 'Cheng Kung University' %} -> {% trans 'Angry Burger' %}</p>
+            <p>[Car 4] {% trans 'Cheng Kung University' %} -> {% trans 'Brunch of San Dao Men Siang Jian' %}</p>
+        </td>
+
+    </tr>
+    <tr>
+        <td>12:40</td>
+
+        <td>
+            <p>[Car 1, 3] {% trans 'Cheng Kung University' %} -> {% trans 'Tainan Cultural and Creative Park' %}</p>
+            <p>[Car 2] {% trans 'Cheng Kung University' %} -> {% trans 'Tsang Fong Art Space' %}</p>
+            <p>[Car 4] {% trans 'Cheng Kung University' %} -> {% trans 'Brunch of San Dao Men Siang Jian' %} -> {% trans 'Tainan Cultural and Creative Park' %} -> {% trans 'Tsang Fong Art Space' %} -> {% trans 'Angry Burger' %}</p>
+        </td>
+    </tr>
+    <tr>
+        <td>13:00</td>
+
+        <td>
+            <p>[Car 2] {% trans 'Cheng Kung University' %} -> {% trans 'Brunch of San Dao Men Siang Jian' %} -> {% trans 'Tainan Cultural and Creative Park' %} -> {% trans 'Tsang Fong Art Space' %} -> {% trans 'Angry Burger' %}</p>
+        </td>
+    </tr>
+    <tr>
+        <td>13:30</td>
+        <td>
+            <p>[Car 3] {% trans 'Cheng Kung University' %} -> {% trans 'Brunch of San Dao Men Siang Jian' %} -> {% trans 'Tainan Cultural and Creative Park' %} -> {% trans 'Tsang Fong Art Space' %} -> {% trans 'Angry Burger' %}</p>
+        </td>
+    </tr>
+
+    </tbody>
+</table>

--- a/src/templates/pycontw-2020/events/community_track.html
+++ b/src/templates/pycontw-2020/events/community_track.html
@@ -43,58 +43,8 @@
 	<h2>{% trans 'Topics &amp; Venues' %}</h2>
 	{% include 'events/_includes/community-track.html' %}
 
-
 	<h2>{% trans 'traffic' %}</h2>
-
-	<p>‼請注意，9/06下午的社群議程場地會由成大移動到各社群議程場地哦
-		為了大家的方便，今年大會安排了交通接駁車方便大家移動到各場地
-		從外縣市來到台南的朋友們可以不必擔心了～
-	</p>
-
-	<table class="table">
-		<thead>
-		<tr>
-			<th>{% trans 'Time' %}</th>
-			<th style="width: 70%">{% trans 'Shuttle bus route' %}</th>
-		</tr>
-		</thead>
-		<tbody>
-		<tr>
-			<td>12:20</td>
-			<td >
-				<p>[Car 1] {% trans 'Cheng Kung University' %} -> {% trans 'Tainan Cultural and Creative Park' %}</p>
-				<p>[Car 2] {% trans 'Cheng Kung University' %} -> {% trans 'Tsang Fong Art Space' %}</p>
-				<p>[Car 3] {% trans 'Cheng Kung University' %} -> {% trans 'Angry Burger' %}</p>
-				<p>[Car 4] {% trans 'Cheng Kung University' %} -> {% trans 'Brunch of San Dao Men Siang Jian' %}</p>
-			</td>
-
-		</tr>
-		<tr>
-			<td>12:40</td>
-
-			<td>
-				<p>[Car 1, 3] {% trans 'Cheng Kung University' %} -> {% trans 'Tainan Cultural and Creative Park' %}</p>
-				<p>[Car 2] {% trans 'Cheng Kung University' %} -> {% trans 'Tsang Fong Art Space' %}</p>
-				<p>[Car 4] {% trans 'Cheng Kung University' %} -> {% trans 'Brunch of San Dao Men Siang Jian' %} -> {% trans 'Tainan Cultural and Creative Park' %} -> {% trans 'Tsang Fong Art Space' %} -> {% trans 'Angry Burger' %}</p>
-			</td>
-		</tr>
-		<tr>
-			<td>13:00</td>
-
-			<td>
-				<p>[Car 2] {% trans 'Cheng Kung University' %} -> {% trans 'Brunch of San Dao Men Siang Jian' %} -> {% trans 'Tainan Cultural and Creative Park' %} -> {% trans 'Tsang Fong Art Space' %} -> {% trans 'Angry Burger' %}</p>
-			</td>
-		</tr>
-		<tr>
-			<td>13:30</td>
-			<td>
-				<p>[Car 3] {% trans 'Cheng Kung University' %} -> {% trans 'Brunch of San Dao Men Siang Jian' %} -> {% trans 'Tainan Cultural and Creative Park' %} -> {% trans 'Tsang Fong Art Space' %} -> {% trans 'Angry Burger' %}</p>
-			</td>
-		</tr>
-
-		</tbody>
-	</table>
-
+	{% include 'events/_includes/community-track-traffic.html' %}
 
 	<script>
 		window.TOKEN = '{{ token|default:'' }}';


### PR DESCRIPTION
## Types of changes
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [X] **Other (please describe)**

## Description
**Describe what the change is**
Move the traffic block into a snippet html template so that the original and ccip version of community track page can include it.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to localhost:8000/cip/community-track
2. Scroll down to the last part
4. The content is inconsistent to the original community track page. Traffic info is not displayed in the OPass version.

## Expected behavior
The OPass version and the web version should be the same. Traffic info should be on both sides.