### PR TITLE
feat(event): Add slido_link field to admin in SponsorEvent

### DIFF
--- a/src/events/admin.py
+++ b/src/events/admin.py
@@ -176,7 +176,7 @@ class SponsoredEventAdmin(admin.ModelAdmin):
     fields = [
         'conference', 'host', 'title', 'slug', 'category', 'language',
         'abstract', 'python_level', 'detailed_description',
-        'recording_policy', 'slide_link',
+        'recording_policy', 'slide_link', 'slido_embed_link',
         'begin_time', 'end_time', 'location',
     ]
     list_display = ['title', 'begin_time', 'end_time', 'location']


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**
- Add slido_link field to admin in SponsorEvent

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to 'admin/events/sponsoredevent' page. 
2. Click on any event
3. Check the field is showed

## Expected behavior
A clear and concise description of what you expected to happen.
The slido link field will appeared as following screenshot.
![image](https://user-images.githubusercontent.com/18432820/92303881-c6ae9e00-efab-11ea-86f1-78085b8d9aa1.png)

## Related Issue
If applicable, refernce to the issue related to this pull request.

## More Information
**Screenshots**
If applicable, add screenshots to help explain your problem.

**Additional context**
Add any other context about the problem here. You may also want to refer
to [how to wirte the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)
