### PR TITLE
fix(talk_detail): Fix wrong width in talk detail view

### DIFF
--- a/src/static/pycontw-2020/styles/_index-partners.scss
+++ b/src/static/pycontw-2020/styles/_index-partners.scss
@@ -58,12 +58,12 @@ h2 {
 		> .grid-layout {
 			display: grid;
 			grid-template-columns: repeat(3, 290px);
-			@media (max-width: 760px) {
+			@media (max-width: 770px) {
 				grid-template-columns: repeat(1, 270px);
 			}
-			column-gap: 40px;
-			row-gap: 40px;
-			margin: 40px;
+			column-gap: 2vw;
+			row-gap: 3vh;
+			margin: 4vw;
 			> .partner-container {
 				background-color: #ffffff6e;
 				border: 1px solid #ffffff00;

--- a/src/static/pycontw-2020/styles/index.scss
+++ b/src/static/pycontw-2020/styles/index.scss
@@ -103,7 +103,7 @@ body {
 }
 
 .index-big-button {
-    width: 510px;
+    width: 100%;
     height: 70px;
     border-radius: 35px;
     font-size: 1.6rem;

--- a/src/static/pycontw-2020/styles/page.scss
+++ b/src/static/pycontw-2020/styles/page.scss
@@ -38,9 +38,10 @@ body {
 
 main {
 	@include content-section;
-	@include container;
+	@include container(100%);
 
 	@include on-desktop {
+		@include container;
 		padding-left: 0;
 		padding-right: 0;
 	}

--- a/src/templates/pycontw-2020/index.html
+++ b/src/templates/pycontw-2020/index.html
@@ -33,7 +33,22 @@
 		</div>
 	</article>
 </section>
+<section class="index-actions">
+	<a class="index-big-button color-jinger-bread" href="{% url 'page' path='events/talks' %}">
+		<i class="icon icon-speaking"></i>
+		<div>{% trans 'Talks' %}</div>
+	</a>
 
+	<a class="index-big-button color-imperial" href="{{ VOLUNTEER_FORM_URL }}" target="_blank" rel="noopener">
+		<i class="icon icon-volunteering"></i>
+		<div>{% trans 'Become a volunteer' %}</div>
+	</a>
+
+	<a class="index-big-button color-dark-gray" href="{% url 'page' path='sponsor/sponsor' %}">
+		<i class="icon icon-sponsor"></i>
+		<div>{% trans 'Sponsor PyCon TW' %}</div>
+	</a>
+</section>
 {% include '_includes/sponsors.html' %}
 
 <div class="main-content">
@@ -57,24 +72,7 @@
 		</article>
 	</section>
 
-    {% comment %}
-	<section class="index-actions">
-		<a class="index-big-button color-jinger-bread" href="{% url 'page' path='events/talks' %}">
-			<i class="icon icon-speaking"></i>
-			<div>{% trans 'Talks' %}</div>
-		</a>
 
-		<a class="index-big-button color-imperial" href="{{ VOLUNTEER_FORM_URL }}" target="_blank" rel="noopener">
-			<i class="icon icon-volunteering"></i>
-			<div>{% trans 'Become a volunteer' %}</div>
-		</a>
-
-		<a class="index-big-button color-dark-gray" href="{% url 'page' path='sponsor/sponsor' %}">
-			<i class="icon icon-sponsor"></i>
-			<div>{% trans 'Sponsor PyCon TW' %}</div>
-		</a>
-	</section>
-    {% endcomment %}
 </div>
 
 

--- a/src/templates/pycontw-2020/index.html
+++ b/src/templates/pycontw-2020/index.html
@@ -34,10 +34,12 @@
 	</article>
 </section>
 <section class="index-actions">
+	{% comment %}
 	<a class="index-big-button color-jinger-bread" href="{% url 'page' path='events/talks' %}">
 		<i class="icon icon-speaking"></i>
 		<div>{% trans 'Talks' %}</div>
 	</a>
+	{% endcomment %}
 
 	<a class="index-big-button color-imperial" href="{{ VOLUNTEER_FORM_URL }}" target="_blank" rel="noopener">
 		<i class="icon icon-volunteering"></i>


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**
You don't need to explain HOW you change the code. Your code, including comments in the code should explicitly
self-describe enough about how you change the code.
- Fix wrong window width in mobile device
- Uncomment volunteer and sponsor section

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to 'Index Page'
2. Check if the "Become a volunteer" and "Sponsor PyCon TW" buttons exist
---
1. Go to https://tw.pycon.org/2020/zh-hant/conference/talk/1164337168361980290/ 
2. Open the debugger and switch to mobile mode, or view the page from your phone.
3. Check if the layout is displayed normally.

## Expected behavior
A clear and concise description of what you expected to happen.
![image](https://user-images.githubusercontent.com/18432820/94129548-10452700-fe8e-11ea-9565-f9fd8d938a95.png)
![image](https://user-images.githubusercontent.com/18432820/94129622-2c48c880-fe8e-11ea-993a-d22053f5414c.png)

## Related Issue
If applicable, refernce to the issue related to this pull request.
#943

## More Information
**Screenshots**
If applicable, add screenshots to help explain your problem.

**Additional context**
Add any other context about the problem here. You may also want to refer
to [how to wirte the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)
