### PR TITLE
feat(user_profile_form): Add photo size validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ Desktop.ini
 
 # Cache
 CACHE
+.mypy_cache/
 
 # Testing
 .coverage

--- a/src/locale/en_US/LC_MESSAGES/django.po
+++ b/src/locale/en_US/LC_MESSAGES/django.po
@@ -4256,6 +4256,10 @@ msgstr "Your image is too small ({width}\\u00d7{height} pixels)."
 msgid "The image you provided is not quadrate."
 msgstr "The image you provided is not quadrate."
 
+#: users/forms.py:151
+msgid "Your image size is too big (>10M)"
+msgstr "Your image size is too big (>10M)"
+
 #: users/forms.py:197
 msgid ""
 "Raw passwords are not stored, so there is no way to see this user's "

--- a/src/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/src/locale/zh_Hant/LC_MESSAGES/django.po
@@ -4143,8 +4143,8 @@ msgid "The image you provided is not quadrate."
 msgstr "提供的圖片並非方型。"
 
 #: users/forms.py:
-msgid "Your image size is too big (> 10M)"
-msgstr "提供的圖片檔案過大 (> 10M)"
+msgid "Your image size is too big (>10M)"
+msgstr "提供的圖片檔案過大 (>10M)"
 
 #: users/forms.py:197
 msgid ""

--- a/src/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/src/locale/zh_Hant/LC_MESSAGES/django.po
@@ -4142,6 +4142,10 @@ msgstr "提供的圖片過小（{width}\\u00d7{height} 像素）。"
 msgid "The image you provided is not quadrate."
 msgstr "提供的圖片並非方型。"
 
+#: users/forms.py:
+msgid "Your image size is too big (> 10M)"
+msgstr "提供的圖片檔案過大 (> 10M)"
+
 #: users/forms.py:197
 msgid ""
 "Raw passwords are not stored, so there is no way to see this user's "

--- a/src/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/src/locale/zh_Hant/LC_MESSAGES/django.po
@@ -4142,7 +4142,7 @@ msgstr "提供的圖片過小（{width}\\u00d7{height} 像素）。"
 msgid "The image you provided is not quadrate."
 msgstr "提供的圖片並非方型。"
 
-#: users/forms.py:
+#: users/forms.py:151
 msgid "Your image size is too big (>10M)"
 msgstr "提供的圖片檔案過大 (>10M)"
 

--- a/src/users/forms.py
+++ b/src/users/forms.py
@@ -148,6 +148,7 @@ class UserProfileUpdateForm(forms.ModelForm):
             'Your image is too small ({width}\u00d7{height} pixels).'
         ),
         'photo_bad_dimension': _('The image you provided is not quadrate.'),
+        'photo_size_too_large': _('Your image size is too big (>10M)'),
     }
 
     class Meta:
@@ -177,6 +178,10 @@ class UserProfileUpdateForm(forms.ModelForm):
                 'photo_bad_dimension', width=width, height=height,
             ))
 
+        if photo.size > 10 * 1024 ** 2:
+            raise forms.ValidationError(self.get_error_message(
+                'photo_size_too_large',
+            ))
         return photo
 
     def get_error_message(self, *args, **kwargs):


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**
- Add photo size validation in profile update form

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to user profile page
2. Upload 8 x 8 image that is larger than 10M.


## Related Issue
If applicable, refernce to the issue related to this pull request.
https://trello.com/c/j0ezAODh/24-fix-all-the-bugs-found-during-the-proposal-system-testing

## More Information
**Screenshots**
![image](https://user-images.githubusercontent.com/18432820/108677551-cd62aa80-7524-11eb-9b5b-18e1ab1a8a43.png)

**Additional context**
Add any other context about the problem here. You may also want to refer
to [how to wirte the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)
