### PR TITLE
feat(url): remove old URLS

### DIFF
--- a/src/core/tests/test_middlewares.py
+++ b/src/core/tests/test_middlewares.py
@@ -6,7 +6,10 @@ from django.test import override_settings
 @pytest.mark.django_db
 def test_locale_fallback_middleware(client, settings):
     response = client.get('/en/', follow=True)
-    assert response.redirect_chain == [('/en-us/', 302)]
+    assert response.redirect_chain == [
+                ('/en-us/', 302),
+                ('/en-us/dashboard/', 302),
+                ('/en-us/accounts/login/?next=/en-us/dashboard/', 302)]
 
 
 @override_settings(USE_I18N=False)

--- a/src/core/tests/test_views.py
+++ b/src/core/tests/test_views.py
@@ -11,7 +11,7 @@ from pytest_django.asserts import assertRedirects
 
 @pytest.mark.django_db
 def test_index_page(client):
-    response = client.get('/en-us/')
+    response = client.get('/en-us/', follow=True)
     assert response.status_code == 200
     assert 'PyCon' in response.content.decode('utf-8')
 

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -3,6 +3,8 @@ import functools
 from django.http import Http404
 from django.views.defaults import page_not_found, server_error
 from django.views.generic import TemplateView
+from django.shortcuts import redirect
+from django.urls import reverse
 
 from .data import EXTRA_DATA
 from .utils import (
@@ -21,6 +23,9 @@ class ExtraDataMixin:
 class IndexView(ExtraDataMixin, TemplateView):
     template_name = 'index.html'
     path = ''
+
+    def dispatch(self, request, *args, **kwargs):
+        return redirect(reverse('user_dashboard'))
 
 
 class FlatPageView(ExtraDataMixin, TemplateView):

--- a/src/events/tests/renderers/test_render_event.py
+++ b/src/events/tests/renderers/test_render_event.py
@@ -3,117 +3,117 @@ import pytest
 from events import renderers
 
 
-def test_render_customevent(parser, utils, custom_partial_belt_event):
-    rendered = renderers.render_customevent(custom_partial_belt_event)
-    assert utils.is_safe(rendered)
-    assert parser.arrange(rendered) == parser.arrange("""
-        <div class="slot-item__content">
-          <div class="slot-item__title">Job Fair</div>
-        </div>
-    """)
+# def test_render_customevent(parser, utils, custom_partial_belt_event):
+#     rendered = renderers.render_customevent(custom_partial_belt_event)
+#     assert utils.is_safe(rendered)
+#     assert parser.arrange(rendered) == parser.arrange("""
+#         <div class="slot-item__content">
+#           <div class="slot-item__title">Job Fair</div>
+#         </div>
+#     """)
 
 
-def test_render_keynoteevent(parser, utils, keynote_belt_event):
-    rendered = renderers.render_keynoteevent(keynote_belt_event)
-    assert utils.is_safe(rendered)
-    assert parser.arrange(rendered) == parser.arrange("""
-        <div class="slot-item__content talk">
-          <div class="slot-item__title">Keynote</div>
-          <a href="/en-us/conference/keynotes/#keynote-speaker-amber-brown"
-               class="talk__speaker">
-            Amber Brown
-          </a>
-        </div>
-    """)
+# def test_render_keynoteevent(parser, utils, keynote_belt_event):
+#     rendered = renderers.render_keynoteevent(keynote_belt_event)
+#     assert utils.is_safe(rendered)
+#     assert parser.arrange(rendered) == parser.arrange("""
+#         <div class="slot-item__content talk">
+#           <div class="slot-item__title">Keynote</div>
+#           <a href="/en-us/conference/keynotes/#keynote-speaker-amber-brown"
+#                class="talk__speaker">
+#             Amber Brown
+#           </a>
+#         </div>
+#     """)
 
 
-def test_render_proposedtalkevent(parser, utils, proposed_talk_block_event):
-    rendered = renderers.render_proposedtalkevent(proposed_talk_block_event)
-    assert utils.is_safe(rendered)
-    assert parser.arrange(rendered) == parser.arrange("""
-        <div class="slot-item__content talk">
-          <a href="/en-us/conference/talk/42/" class="talk__title">
-            Beyond the Style Guides&lt;br&gt;
-          </a>
-          <a href="/en-us/conference/talk/42/#speaker-content"
-              class="talk__speaker">
-            User and Misaki Mei
-          </a>
-          <div class="talk__lang">EN Slides</div>
-        </div>
-    """)
+# def test_render_proposedtalkevent(parser, utils, proposed_talk_block_event):
+#     rendered = renderers.render_proposedtalkevent(proposed_talk_block_event)
+#     assert utils.is_safe(rendered)
+#     assert parser.arrange(rendered) == parser.arrange("""
+#         <div class="slot-item__content talk">
+#           <a href="/en-us/conference/talk/42/" class="talk__title">
+#             Beyond the Style Guides&lt;br&gt;
+#           </a>
+#           <a href="/en-us/conference/talk/42/#speaker-content"
+#               class="talk__speaker">
+#             User and Misaki Mei
+#           </a>
+#           <div class="talk__lang">EN Slides</div>
+#         </div>
+#     """)
 
 
-def test_render_sponsoredevent(parser, utils, sponsored_block_event):
-    rendered = renderers.render_sponsoredevent(sponsored_block_event)
-    assert utils.is_safe(rendered)
-    assert parser.arrange(rendered) == parser.arrange("""
-        <div class="slot-item__content sponsored talk">
-          <a href="/en-us/conference/talk/sponsored/camera-engine/"
-              class="talk__title">
-            Camera engine office woman lights
-          </a>
-          <a href="/en-us/conference/talk/sponsored/camera-engine/#speaker-content"
-              class="talk__speaker">
-            User
-          </a>
-          <div class="talk__lang">ZH</div>
-        </div>
-    """)
+# def test_render_sponsoredevent(parser, utils, sponsored_block_event):
+#     rendered = renderers.render_sponsoredevent(sponsored_block_event)
+#     assert utils.is_safe(rendered)
+#     assert parser.arrange(rendered) == parser.arrange("""
+#         <div class="slot-item__content sponsored talk">
+#           <a href="/en-us/conference/talk/sponsored/camera-engine/"
+#               class="talk__title">
+#             Camera engine office woman lights
+#           </a>
+#           <a href="/en-us/conference/talk/sponsored/camera-engine/#speaker-content"
+#               class="talk__speaker">
+#             User
+#           </a>
+#           <div class="talk__lang">ZH</div>
+#         </div>
+#     """)
 
 
-@pytest.mark.parametrize('event_key', [
-    'custom_event', 'keynote_event', 'proposed_talk_event', 'sponsored_event',
-])
-def test_render_event(parser, utils, events, event_key):
-    event = events[event_key]
-    rendered = renderers.render_event(event)
-    assert utils.is_safe(rendered)
+# @pytest.mark.parametrize('event_key', [
+#     'custom_event', 'keynote_event', 'proposed_talk_event', 'sponsored_event',
+# ])
+# def test_render_event(parser, utils, events, event_key):
+#     event = events[event_key]
+#     rendered = renderers.render_event(event)
+#     assert utils.is_safe(rendered)
 
-    expected = {
-        'custom_event': """
-            <div class="slot-item__content">
-              <div class="slot-item__title">Job Fair</div>
-            </div>""",
-        'keynote_event': """
-            <div class="slot-item__content talk">
-              <div class="slot-item__title">Keynote</div>
-              <a href="/en-us/conference/keynotes/#keynote-speaker-amber-brown"
-                   class="talk__speaker">
-                Amber Brown
-              </a>
-            </div>""",
-        'proposed_talk_event': """
-            <div class="slot-item__content talk">
-              <a href="/en-us/conference/talk/42/" class="talk__title">
-                Beyond the Style Guides&lt;br&gt;
-              </a>
-              <a href="/en-us/conference/talk/42/#speaker-content"
-                  class="talk__speaker">
-                User and Misaki Mei
-              </a>
-              <div class="talk__lang">EN Slides</div>
-            </div>""",
-        'sponsored_event': (
-            '<div class="slot-item__content sponsored talk">'
-            '  <a href="/en-us/conference/talk/sponsored/camera-engine/"'
-            '      class="talk__title">'
-            '    Camera engine office woman lights'
-            '  </a>'
-            '  <a href="/en-us/conference/talk/sponsored/camera-engine/'
-            '#speaker-content" class="talk__speaker">'
-            '    User'
-            '  </a>'
-            '  <div class="talk__lang">ZH</div>'
-            '</div>'),
-    }[event_key]
-    assert parser.arrange(rendered) == parser.arrange(expected)
+#     expected = {
+#         'custom_event': """
+#             <div class="slot-item__content">
+#               <div class="slot-item__title">Job Fair</div>
+#             </div>""",
+#         'keynote_event': """
+#             <div class="slot-item__content talk">
+#               <div class="slot-item__title">Keynote</div>
+#               <a href="/en-us/conference/keynotes/#keynote-speaker-amber-brown"
+#                    class="talk__speaker">
+#                 Amber Brown
+#               </a>
+#             </div>""",
+#         'proposed_talk_event': """
+#             <div class="slot-item__content talk">
+#               <a href="/en-us/conference/talk/42/" class="talk__title">
+#                 Beyond the Style Guides&lt;br&gt;
+#               </a>
+#               <a href="/en-us/conference/talk/42/#speaker-content"
+#                   class="talk__speaker">
+#                 User and Misaki Mei
+#               </a>
+#               <div class="talk__lang">EN Slides</div>
+#             </div>""",
+#         'sponsored_event': (
+#             '<div class="slot-item__content sponsored talk">'
+#             '  <a href="/en-us/conference/talk/sponsored/camera-engine/"'
+#             '      class="talk__title">'
+#             '    Camera engine office woman lights'
+#             '  </a>'
+#             '  <a href="/en-us/conference/talk/sponsored/camera-engine/'
+#             '#speaker-content" class="talk__speaker">'
+#             '    User'
+#             '  </a>'
+#             '  <div class="talk__lang">ZH</div>'
+#             '</div>'),
+#     }[event_key]
+#     assert parser.arrange(rendered) == parser.arrange(expected)
 
 
-def test_render_event_fail(user):
-    with pytest.raises(ValueError) as ctx:
-        renderers.render_event(user)
-    assert str(ctx.value) == (
-        "No suitable renderer for <User: user@user.me> "
-        "of <class 'users.models.User'>"
-    )
+# def test_render_event_fail(user):
+#     with pytest.raises(ValueError) as ctx:
+#         renderers.render_event(user)
+#     assert str(ctx.value) == (
+#         "No suitable renderer for <User: user@user.me> "
+#         "of <class 'users.models.User'>"
+#     )

--- a/src/pycontw2016/urls.py
+++ b/src/pycontw2016/urls.py
@@ -15,11 +15,11 @@ urlpatterns = i18n_patterns(
     url(r'^$', index, name='index'),
     url(r'^dashboard/$', user_dashboard, name='user_dashboard'),
     url(r'^accounts/', include('users.urls')),
-    url(r'^conference/', include('events.urls')),
+    #url(r'^conference/', include('events.urls')),
     url(r'^proposals/', include('proposals.urls')),
     url(r'^reviews/', include('reviews.urls')),
-    url(r'^sponsors/', include('sponsors.urls')),
-    url(r'^ext/', include('ext2020.urls')),
+    #url(r'^sponsors/', include('sponsors.urls')),
+    #url(r'^ext/', include('ext2020.urls')),
 
     # Match everything except admin, media, static, and error pages.
     url(r'^(?!admin|{media}|{static}|404|500/)(?P<path>.*)/$'.format(


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

We're now attempted to migrate all the attendee-facing pages to our new frontend project and remain the pages related to the proposal & review system in pycon.tw backend project. Thus, remove the URLs that are deprecated.