### PR TITLE
chore(deps): upgrade Django to 3.1.7 & django-modeltranslation to 0.16.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Django
 # https://www.djangoproject.com/
-Django==3.0.7
+Django==3.1.7
 
 # A simple, easy access key-value registry for Django
 # https://github.com/yychen/dj-registry
@@ -42,7 +42,7 @@ django-extensions==2.2.6
 
 # Translates Django models using a registration approach.
 # https://github.com/deschler/django-modeltranslation
-django-modeltranslation==0.14.2
+django-modeltranslation==0.16.2
 
 # Native Django task queue, scheduler and worker application using Python
 # multiprocessing.


### PR DESCRIPTION
## Types of changes

- [ ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [x] **Other (upgrade dependencies)**

## Description

**[WHY]**

We'd like to adopt callable for model storage (see doc for details: https://docs.djangoproject.com/en/3.1/topics/files/#using-a-callable) in #987 but it's supported only in Django 3.1 or later.

**[HOW]**

Upgrade Django to 3.1.7 but django-modeltranslation also need to be upgraded to 0.16.2 for compatibility.

