### PR TITLE
fix(coc): handle redirection target after posting the coc agreement

### DIFF
--- a/src/users/views.py
+++ b/src/users/views.py
@@ -150,7 +150,11 @@ def coc_agree(request):
                 agreement = CocRecord(user=request.user, coc_version=settings.COC_VERSION)
 
             agreement.save()
-            return redirect(request.GET.get('next'))
+
+            # The query param indicating redirect target (setup by CocAgreementMixin) can be removed after set_language.
+            # Redirect to dashboard intead if this situation happened.
+            redirect_to = request.GET.get('next', reverse('user_dashboard'))
+            return redirect(redirect_to)
     else:
         form = CocAgreementForm()
 


### PR DESCRIPTION


## Types of changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

**[WHY]**

The redirection target stored in the query params (?next=/path/to/submission/page) can be removed after the user changes language, which causes an unhandled exception.

**[HOW]**

Redirect to user dashboard instead if the aforementioned situation happened.