### PR TITLE
fix(reviews/views): use default alias for annotation

### DIFF
--- a/src/events/api/serializers.py
+++ b/src/events/api/serializers.py
@@ -25,7 +25,7 @@ class TalkDetailSerializer(serializers.ModelSerializer):
                       'github_profile_url': i.user.github_profile_url,
                       'twitter_profile_url': i.user.twitter_profile_url,
                       'facebook_profile_url': i.user.facebook_profile_url}).get_initial(),
-                       serializer=PrimarySpeakerSerializer) for i in obj.speakers]
+                serializer=PrimarySpeakerSerializer) for i in obj.speakers]
 
     class Meta:
         model = models.TalkProposal

--- a/src/reviews/views.py
+++ b/src/reviews/views.py
@@ -38,12 +38,12 @@ class TalkProposalListView(ReviewableMixin, PermissionRequiredMixin, ListView):
     }
     order_keys = {
         'title': 'title',
-        'count': 'review_count',
+        'count': 'review__count',
         'category': 'category',
         'level': 'python_level',
         'lang': 'language',
         '-title': '-title',
-        '-count': '-review_count',
+        '-count': '-review__count',
         '-category': '-category',
         '-level': '-python_level',
         '-lang': '-language',
@@ -62,7 +62,7 @@ class TalkProposalListView(ReviewableMixin, PermissionRequiredMixin, ListView):
             .filter_reviewable(user)
             .exclude(accepted__isnull=False)
             .exclude(review__reviewer=user)
-            .annotate(review_count=Count('review'))
+            .annotate(Count('review'))
         )
         # params = self.request.GET
         # category = params.get('category', '').upper()
@@ -93,7 +93,7 @@ class TalkProposalListView(ReviewableMixin, PermissionRequiredMixin, ListView):
             TalkProposal.objects
             .filter_reviewable(self.request.user)
             .filter(accepted__isnull=False)
-            .annotate(review_count=Count('review'))
+            .annotate(Count('review'))
         )
 
         vote_count_pairs = (

--- a/src/templates/default/reviews/_includes/proposal_table.html
+++ b/src/templates/default/reviews/_includes/proposal_table.html
@@ -4,8 +4,8 @@
 	<tr>
 		{% if not verdict %}
 			<th width="1%">
-				<a {% if ordering == 'review_count' %}class="active asc" href="?order=-count"
-					 {% elif ordering == '-review_count' %}class="active desc" href="?order=count"
+				<a {% if ordering == 'review__count' %}class="active asc" href="?order=-count"
+					 {% elif ordering == '-review__count' %}class="active desc" href="?order=count"
 					 {% else %}href="?order=count"{% endif %}>
 					{% trans 'Reviewed' %}
 					<i class="fa fa-sort fa-lg"></i>
@@ -43,10 +43,10 @@
 	{% for proposal in proposals %}
 		<tr>
 			{% if proposal.accepted == None %}
-				<td>{{ proposal.review_count }}</td>
+				<td>{{ proposal.review__count }}</td>
 			{% endif %}
 			<td class="proposal-title">
-				<div  {% if proposal.review_count > reviews_enough %} class="grayed-out" {% endif %} >{{ proposal.title }}</div>
+				<div  {% if proposal.review__count > reviews_enough %} class="grayed-out" {% endif %} >{{ proposal.title }}</div>
 			</td>
 			<td class="hidden-md hidden-sm hidden-xs">{{ proposal.get_language_display }}</td>
 			{% if proposal.accepted != None %}


### PR DESCRIPTION
## Types of changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

Return 5XX when accessing the review portal with ordering by review count (`<host>/<lang>/reviews/?order=count`) as a reviewer. The error log is shown below:

![image](https://user-images.githubusercontent.com/24987826/116283714-ca06cc00-a7be-11eb-956a-5a62e26cfc30.png)

Using default alias solves this issue.