### PR TITLE
fix(api/openrole): duplicated job lists

### DIFF
--- a/src/sponsors/api/views.py
+++ b/src/sponsors/api/views.py
@@ -35,28 +35,27 @@ class SponsorAPIView(views.APIView):
 
 class JobAPIView(views.APIView):
     def get(self, request):
-        sponsor_has_open_role = set(OpenRole.objects.values_list('sponsor', flat=True))
-        sponsor_set = Sponsor.objects.filter(id__in=sponsor_has_open_role).order_by('level')
+        open_roles = OpenRole.objects.all().order_by('sponsor__level')
 
-        open_roles = OpenRole.objects.filter(sponsor__in=sponsor_has_open_role).order_by('sponsor__level')
-
-        response_data = {"data": []}
-        for sponsor in sponsor_set:
-            jobs = []
-            for open_role in open_roles:
-                jobs.append({
-                    "job_url": open_role.url,
-                    "job_name_en_us": open_role.name_en_us,
-                    "job_name_zh_hant": open_role.name_zh_hant,
-                    "job_description_en_us": open_role.description_en_us,
-                    "job_description_zh_hant": open_role.description_zh_hant,
-                    "job_requirements_en_us": open_role.requirements_en_us,
-                    "job_requirements_zh_hant": open_role.requirements_zh_hant,
-                })
-            response_data["data"].append({
-                "sponsor_logo_url": sponsor.logo.url if sponsor.logo else '',
-                "sponsor_name": sponsor.name,
-                "jobs": jobs
+        data = {}
+        for open_role in open_roles:
+            sponsor_id = open_role.sponsor.id
+            if sponsor_id not in data:
+                logo = open_role.sponsor.logo
+                data[sponsor_id] = {
+                    "sponsor_logo_url": logo.url if logo else '',
+                    "sponsor_name": open_role.sponsor.name,
+                    "jobs": [],
+                }
+            data[sponsor_id]["jobs"].append({
+                "job_url": open_role.url,
+                "job_name_en_us": open_role.name_en_us,
+                "job_name_zh_hant": open_role.name_zh_hant,
+                "job_description_en_us": open_role.description_en_us,
+                "job_description_zh_hant": open_role.description_zh_hant,
+                "job_requirements_en_us": open_role.requirements_en_us,
+                "job_requirements_zh_hant": open_role.requirements_zh_hant,
             })
 
+        response_data = {"data": data.values()}
         return Response(response_data)

--- a/src/sponsors/api/views.py
+++ b/src/sponsors/api/views.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from rest_framework import views
 from rest_framework.response import Response
 
@@ -37,7 +39,7 @@ class JobAPIView(views.APIView):
     def get(self, request):
         open_roles = OpenRole.objects.all().order_by('sponsor__level')
 
-        data = {}
+        data = OrderedDict()
         for open_role in open_roles:
             sponsor_id = open_role.sponsor.id
             if sponsor_id not in data:
@@ -57,5 +59,5 @@ class JobAPIView(views.APIView):
                 "job_requirements_zh_hant": open_role.requirements_zh_hant,
             })
 
-        response_data = {"data": data.values()}
+        response_data = {"data": list(data.values())}
         return Response(response_data)


### PR DESCRIPTION
## Types of changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

In the response of `GET` `/api/sponsors/jobs/`, the job list is mistakenly copied to all the sponsors.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Call API: `GET` `/api/sponsors/jobs/`
2. Checkout response

## Expected behavior

The job lists are correctly grouped by the sponsors.
