### PR TITLE
Modify event API response format for frontend design spec

### DIFF
--- a/src/events/api/serializers.py
+++ b/src/events/api/serializers.py
@@ -53,8 +53,8 @@ class TalkProposalSerializer(serializers.ModelSerializer):
 
     def get_speakers(self, obj):
         request = self.context.get('request')
-        users = [s.user for s in obj.speakers]
-        return format_speakers_data(request, users, show_details=True)
+        speakers = [s.user for s in obj.speakers]
+        return format_speakers_data(request, speakers, show_details=True)
 
     class Meta:
         model = TalkProposal
@@ -84,8 +84,8 @@ class TalkListSerializer(serializers.ModelSerializer):
 
     def get_speakers(self, obj):
         request = self.context.get('request')
-        users = [s.user for s in obj.speakers]
-        return format_speakers_data(request, users)
+        speakers = [s.user for s in obj.speakers]
+        return format_speakers_data(request, speakers)
 
     class Meta:
         model = TalkProposal
@@ -138,8 +138,8 @@ class TutorialProposalSerializer(serializers.ModelSerializer):
 
     def get_speakers(self, obj):
         request = self.context.get('request')
-        users = [s.user for s in obj.speakers]
-        return format_speakers_data(request, users, show_details=True)
+        speakers = [s.user for s in obj.speakers]
+        return format_speakers_data(request, speakers, show_details=True)
 
     class Meta:
         model = TutorialProposal
@@ -167,8 +167,8 @@ class TutorialListSerializer(serializers.ModelSerializer):
 
     def get_speakers(self, obj):
         request = self.context.get('request')
-        users = [s.user for s in obj.speakers]
-        return format_speakers_data(request, users)
+        speakers = [s.user for s in obj.speakers]
+        return format_speakers_data(request, speakers)
 
     class Meta:
         model = TutorialProposal

--- a/src/events/api/serializers.py
+++ b/src/events/api/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from rest_framework.utils.serializer_helpers import ReturnDict
 
 from events.models import ProposedTalkEvent, ProposedTutorialEvent, SponsoredEvent, KeynoteEvent
-from proposals.models import TalkProposal
+from proposals.models import TalkProposal, TutorialProposal
 
 
 class PrimarySpeakerSerializer(serializers.Serializer):
@@ -79,38 +79,40 @@ class SponsoredEventSerializer(serializers.ModelSerializer):
         fields = ["slug", "title", "host_name"]
 
 
-class TutorialDetailSerializer(serializers.ModelSerializer):
-    title = serializers.CharField(source='proposal.title')
-    date = serializers.DateTimeField(format='%Y-%m-%d', source='begin_time.value')
-    begin_time = serializers.DateTimeField(format='%Y-%m-%d %H:%M:%S', source='begin_time.value')
-    end_time = serializers.DateTimeField(format='%Y-%m-%d %H:%M:%S', source='end_time.value')
-    category = serializers.CharField(source='proposal.category')
-    language = serializers.CharField(source='proposal.language')
-    python_level = serializers.CharField(source='proposal.python_level')
-    abstract = serializers.CharField(source='proposal.abstract')
-    detailed_description = serializers.CharField(source='proposal.detailed_description')
-    slide_link = serializers.CharField(source='proposal.slide_link')
-    slido_embed_link = serializers.CharField(source='proposal.slido_embed_link')
+class TutorialProposalSerializer(serializers.ModelSerializer):
     speakers = serializers.SerializerMethodField()
 
     def get_speakers(self, obj):
-        return [
-            ReturnDict(PrimarySpeakerSerializer(
-                data={'thumbnail_url': i.user.get_thumbnail_url(),
-                      'name': i.user.speaker_name,
-                      'github_profile_url': i.user.github_profile_url,
-                      'twitter_profile_url': i.user.twitter_profile_url,
-                      'facebook_profile_url': i.user.facebook_profile_url}).get_initial(),
-                serializer=PrimarySpeakerSerializer) for i in obj.proposal.speakers]
+        request = self.context.get('request')
+        return format_speakers_data(request, obj.speakers, show_details=True)
+
+    class Meta:
+        model = TutorialProposal
+        fields = [
+            "title", "category", "language", "python_level",
+            "recording_policy", "abstract", "detailed_description",
+            "slide_link", "slido_embed_link", "speakers",
+        ]
+
+
+class TutorialDetailSerializer(serializers.ModelSerializer):
+    proposal = TutorialProposalSerializer()
 
     class Meta:
         model = ProposedTutorialEvent
-        fields = [
-            "title", "location", "date", "begin_time", "end_time",
-            "category", "language", "python_level", "abstract",
-            "detailed_description", "slide_link",
-            "slido_embed_link", "speakers",
-        ]
+        fields = ['proposal', 'begin_time', 'end_time', 'is_remote', 'location']
+
+
+class TutorialListSerializer(serializers.ModelSerializer):
+    speakers = serializers.SerializerMethodField()
+
+    def get_speakers(self, obj):
+        request = self.context.get('request')
+        return format_speakers_data(request, obj.speakers)
+
+    class Meta:
+        model = TutorialProposal
+        fields = ["id", "title", "category", "speakers"]
 
 
 class KeynoteEventSerializer(serializers.ModelSerializer):

--- a/src/events/api/serializers.py
+++ b/src/events/api/serializers.py
@@ -13,19 +13,28 @@ class PrimarySpeakerSerializer(serializers.Serializer):
     facebook_profile_url = serializers.CharField()
 
 
+def format_speakers_data(request, speakers):
+    formatted = []
+    for speaker in speakers:
+        thumbnail_absolute_uri = request.build_absolute_uri(speaker.user.get_thumbnail_url())
+        data = {
+            'thumbnail_url': thumbnail_absolute_uri,
+            'name': speaker.user.speaker_name,
+            'github_profile_url': speaker.user.github_profile_url,
+            'twitter_profile_url': speaker.user.twitter_profile_url,
+            'facebook_profile_url': speaker.user.facebook_profile_url
+        }
+        serialized = PrimarySpeakerSerializer(data=data).get_initial()
+        formatted.append(ReturnDict(serialized, serializer=PrimarySpeakerSerializer))
+    return formatted
+
+
 class TalkDetailSerializer(serializers.ModelSerializer):
     speakers = serializers.SerializerMethodField()
 
     def get_speakers(self, obj):
         request = self.context.get('request')
-        return [
-            ReturnDict(PrimarySpeakerSerializer(
-                data={'thumbnail_url': request.build_absolute_uri(i.user.get_thumbnail_url()),
-                      'name': i.user.speaker_name,
-                      'github_profile_url': i.user.github_profile_url,
-                      'twitter_profile_url': i.user.twitter_profile_url,
-                      'facebook_profile_url': i.user.facebook_profile_url}).get_initial(),
-                serializer=PrimarySpeakerSerializer) for i in obj.speakers]
+        return format_speakers_data(request, obj.speakers)
 
     class Meta:
         model = TalkProposal
@@ -49,14 +58,7 @@ class TalkListSerializer(serializers.ModelSerializer):
 
     def get_speakers(self, obj):
         request = self.context.get('request')
-        return [
-            ReturnDict(PrimarySpeakerSerializer(
-                data={'thumbnail_url': request.build_absolute_uri(i.user.get_thumbnail_url()),
-                      'name': i.user.speaker_name,
-                      'github_profile_url': i.user.github_profile_url,
-                      'twitter_profile_url': i.user.twitter_profile_url,
-                      'facebook_profile_url': i.user.facebook_profile_url}).get_initial(),
-                serializer=PrimarySpeakerSerializer) for i in obj.speakers]
+        return format_speakers_data(request, obj.speakers)
 
     class Meta:
         model = TalkProposal

--- a/src/events/api/serializers.py
+++ b/src/events/api/serializers.py
@@ -11,9 +11,10 @@ class PrimarySpeakerSerializer(serializers.Serializer):
     github_profile_url = serializers.CharField()
     twitter_profile_url = serializers.CharField()
     facebook_profile_url = serializers.CharField()
+    bio = serializers.CharField()
 
 
-def format_speakers_data(request, speakers):
+def format_speakers_data(request, speakers, show_details=False):
     formatted = []
     for speaker in speakers:
         thumbnail_absolute_uri = request.build_absolute_uri(speaker.user.get_thumbnail_url())
@@ -24,6 +25,8 @@ def format_speakers_data(request, speakers):
             'twitter_profile_url': speaker.user.twitter_profile_url,
             'facebook_profile_url': speaker.user.facebook_profile_url
         }
+        if show_details:
+            data = {**data, 'bio': speaker.user.bio}
         serialized = PrimarySpeakerSerializer(data=data).get_initial()
         formatted.append(ReturnDict(serialized, serializer=PrimarySpeakerSerializer))
     return formatted
@@ -34,7 +37,7 @@ class TalkProposalSerializer(serializers.ModelSerializer):
 
     def get_speakers(self, obj):
         request = self.context.get('request')
-        return format_speakers_data(request, obj.speakers)
+        return format_speakers_data(request, obj.speakers, show_details=True)
 
     class Meta:
         model = TalkProposal

--- a/src/events/api/serializers.py
+++ b/src/events/api/serializers.py
@@ -16,20 +16,19 @@ class PrimarySpeakerSerializer(serializers.Serializer):
 
 def format_speakers_data(request, speakers, show_details=False):
     formatted = []
-    for speaker in speakers:
-        u = speaker.user
-        thumbnail_absolute_uri = request.build_absolute_uri(u.get_thumbnail_url())
+    for s in speakers:
+        thumbnail_absolute_uri = request.build_absolute_uri(s.get_thumbnail_url())
         data = {
             'thumbnail_url': thumbnail_absolute_uri,
-            'name': u.speaker_name,
+            'name': s.speaker_name,
         }
         if show_details:
             data = {
                 **data,
-                'bio': u.bio,
-                'github_profile_url': u.github_profile_url,
-                'twitter_profile_url': u.twitter_profile_url,
-                'facebook_profile_url': u.facebook_profile_url,
+                'bio': s.bio,
+                'github_profile_url': s.github_profile_url,
+                'twitter_profile_url': s.twitter_profile_url,
+                'facebook_profile_url': s.facebook_profile_url,
             }
         serialized = PrimarySpeakerSerializer(data=data).get_initial()
         formatted.append(ReturnDict(serialized, serializer=PrimarySpeakerSerializer))
@@ -41,7 +40,8 @@ class TalkProposalSerializer(serializers.ModelSerializer):
 
     def get_speakers(self, obj):
         request = self.context.get('request')
-        return format_speakers_data(request, obj.speakers, show_details=True)
+        users = [s.user for s in obj.speakers]
+        return format_speakers_data(request, users, show_details=True)
 
     class Meta:
         model = TalkProposal
@@ -66,7 +66,8 @@ class TalkListSerializer(serializers.ModelSerializer):
 
     def get_speakers(self, obj):
         request = self.context.get('request')
-        return format_speakers_data(request, obj.speakers)
+        users = [s.user for s in obj.speakers]
+        return format_speakers_data(request, users)
 
     class Meta:
         model = TalkProposal
@@ -74,12 +75,15 @@ class TalkListSerializer(serializers.ModelSerializer):
 
 
 class SponsoredEventSerializer(serializers.ModelSerializer):
+    speakers = serializers.SerializerMethodField()
 
-    host_name = serializers.CharField(source="host.speaker_name", required=False)
+    def get_speakers(self, obj):
+        request = self.context.get('request')
+        return format_speakers_data(request, [obj.host])
 
     class Meta:
         model = SponsoredEvent
-        fields = ["slug", "title", "host_name"]
+        fields = ["id", "title", "category", "speakers"]
 
 
 class TutorialProposalSerializer(serializers.ModelSerializer):
@@ -87,7 +91,8 @@ class TutorialProposalSerializer(serializers.ModelSerializer):
 
     def get_speakers(self, obj):
         request = self.context.get('request')
-        return format_speakers_data(request, obj.speakers, show_details=True)
+        users = [s.user for s in obj.speakers]
+        return format_speakers_data(request, users, show_details=True)
 
     class Meta:
         model = TutorialProposal
@@ -111,7 +116,8 @@ class TutorialListSerializer(serializers.ModelSerializer):
 
     def get_speakers(self, obj):
         request = self.context.get('request')
-        return format_speakers_data(request, obj.speakers)
+        users = [s.user for s in obj.speakers]
+        return format_speakers_data(request, users)
 
     class Meta:
         model = TutorialProposal

--- a/src/events/api/serializers.py
+++ b/src/events/api/serializers.py
@@ -22,12 +22,15 @@ def format_speakers_data(request, speakers, show_details=False):
         data = {
             'thumbnail_url': thumbnail_absolute_uri,
             'name': u.speaker_name,
-            'github_profile_url': u.github_profile_url,
-            'twitter_profile_url': u.twitter_profile_url,
-            'facebook_profile_url': u.facebook_profile_url
         }
         if show_details:
-            data = {**data, 'bio': u.bio}
+            data = {
+                **data,
+                'bio': u.bio,
+                'github_profile_url': u.github_profile_url,
+                'twitter_profile_url': u.twitter_profile_url,
+                'facebook_profile_url': u.facebook_profile_url,
+            }
         serialized = PrimarySpeakerSerializer(data=data).get_initial()
         formatted.append(ReturnDict(serialized, serializer=PrimarySpeakerSerializer))
     return formatted

--- a/src/events/api/serializers.py
+++ b/src/events/api/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from rest_framework.utils.serializer_helpers import ReturnDict
 
-from events.models import ProposedTutorialEvent, SponsoredEvent, KeynoteEvent
+from events.models import ProposedTalkEvent, ProposedTutorialEvent, SponsoredEvent, KeynoteEvent
 from proposals.models import TalkProposal
 
 
@@ -29,7 +29,7 @@ def format_speakers_data(request, speakers):
     return formatted
 
 
-class TalkDetailSerializer(serializers.ModelSerializer):
+class TalkProposalSerializer(serializers.ModelSerializer):
     speakers = serializers.SerializerMethodField()
 
     def get_speakers(self, obj):
@@ -51,6 +51,14 @@ class TalkDetailSerializer(serializers.ModelSerializer):
             # "sponsored"
             "speakers"
         ]
+
+
+class TalkDetailSerializer(serializers.ModelSerializer):
+    proposal = TalkProposalSerializer()
+
+    class Meta:
+        model = ProposedTalkEvent
+        fields = ['proposal', 'begin_time', 'end_time', 'is_remote', 'location']
 
 
 class TalkListSerializer(serializers.ModelSerializer):

--- a/src/events/api/serializers.py
+++ b/src/events/api/serializers.py
@@ -17,16 +17,17 @@ class PrimarySpeakerSerializer(serializers.Serializer):
 def format_speakers_data(request, speakers, show_details=False):
     formatted = []
     for speaker in speakers:
-        thumbnail_absolute_uri = request.build_absolute_uri(speaker.user.get_thumbnail_url())
+        u = speaker.user
+        thumbnail_absolute_uri = request.build_absolute_uri(u.get_thumbnail_url())
         data = {
             'thumbnail_url': thumbnail_absolute_uri,
-            'name': speaker.user.speaker_name,
-            'github_profile_url': speaker.user.github_profile_url,
-            'twitter_profile_url': speaker.user.twitter_profile_url,
-            'facebook_profile_url': speaker.user.facebook_profile_url
+            'name': u.speaker_name,
+            'github_profile_url': u.github_profile_url,
+            'twitter_profile_url': u.twitter_profile_url,
+            'facebook_profile_url': u.facebook_profile_url
         }
         if show_details:
-            data = {**data, 'bio': speaker.user.bio}
+            data = {**data, 'bio': u.bio}
         serialized = PrimarySpeakerSerializer(data=data).get_initial()
         formatted.append(ReturnDict(serialized, serializer=PrimarySpeakerSerializer))
     return formatted
@@ -42,17 +43,10 @@ class TalkProposalSerializer(serializers.ModelSerializer):
     class Meta:
         model = TalkProposal
         fields = [
-            "title",
-            "category",
-            "language",
-            "python_level",
-            "recording_policy",
-            "abstract",
-            "detailed_description",
-            "slide_link",
-            "slido_embed_link",
+            "title", "category", "language", "python_level",
+            "recording_policy", "abstract", "detailed_description",
+            "slide_link", "slido_embed_link", "speakers",
             # "sponsored"
-            "speakers"
         ]
 
 
@@ -82,11 +76,7 @@ class SponsoredEventSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = SponsoredEvent
-        fields = [
-            "slug",
-            "title",
-            "host_name"
-        ]
+        fields = ["slug", "title", "host_name"]
 
 
 class TutorialDetailSerializer(serializers.ModelSerializer):
@@ -116,19 +106,10 @@ class TutorialDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProposedTutorialEvent
         fields = [
-            "title",
-            "location",
-            "date",
-            "begin_time",
-            "end_time",
-            "category",
-            "language",
-            "python_level",
-            "abstract",
-            "detailed_description",
-            "slide_link",
-            "slido_embed_link",
-            "speakers"
+            "title", "location", "date", "begin_time", "end_time",
+            "category", "language", "python_level", "abstract",
+            "detailed_description", "slide_link",
+            "slido_embed_link", "speakers",
         ]
 
 

--- a/src/events/api/serializers.py
+++ b/src/events/api/serializers.py
@@ -17,9 +17,10 @@ class TalkDetailSerializer(serializers.ModelSerializer):
     speakers = serializers.SerializerMethodField()
 
     def get_speakers(self, obj):
+        request = self.context.get('request')
         return [
             ReturnDict(PrimarySpeakerSerializer(
-                data={'thumbnail_url': i.user.get_thumbnail_url(),
+                data={'thumbnail_url': request.build_absolute_uri(i.user.get_thumbnail_url()),
                       'name': i.user.speaker_name,
                       'github_profile_url': i.user.github_profile_url,
                       'twitter_profile_url': i.user.twitter_profile_url,
@@ -40,7 +41,6 @@ class TalkDetailSerializer(serializers.ModelSerializer):
             "slido_embed_link",
             # "sponsored"
             "speakers"
-
         ]
 
 
@@ -48,9 +48,10 @@ class TalkListSerializer(serializers.ModelSerializer):
     speakers = serializers.SerializerMethodField()
 
     def get_speakers(self, obj):
+        request = self.context.get('request')
         return [
             ReturnDict(PrimarySpeakerSerializer(
-                data={'thumbnail_url': i.user.get_thumbnail_url(),
+                data={'thumbnail_url': request.build_absolute_uri(i.user.get_thumbnail_url()),
                       'name': i.user.speaker_name,
                       'github_profile_url': i.user.github_profile_url,
                       'twitter_profile_url': i.user.twitter_profile_url,
@@ -59,13 +60,7 @@ class TalkListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = TalkProposal
-        fields = [
-            "id",
-            "title",
-            "category",
-            "labels",
-            "speakers",
-        ]
+        fields = ["id", "title", "category", "speakers"]
 
 
 class SponsoredEventSerializer(serializers.ModelSerializer):

--- a/src/events/api/urls.py
+++ b/src/events/api/urls.py
@@ -11,5 +11,4 @@ urlpatterns = [
     path('tutorials/', views.TutorialListAPIView.as_view()),
     path('talk/<int:pk>/', views.TalkDetailAPIView.as_view()),
     path('tutorial/<int:pk>/', views.TutorialDetailAPIView.as_view()),
-    path('sponsors-event/', views.SponsoredEventListAPIView.as_view()),
 ]

--- a/src/events/api/views.py
+++ b/src/events/api/views.py
@@ -25,13 +25,13 @@ class TalkDetailAPIView(RetrieveAPIView):
 
     def get_serializer_class(self):
         is_sponsored = self.request.GET.get('isSponsored')
-        if is_sponsored is not None:
+        if is_sponsored:
             return serializers.SponsoredEventDetailSerializer
         return serializers.TalkDetailSerializer
 
     def get_queryset(self):
         is_sponsored = self.request.GET.get('isSponsored')
-        if is_sponsored is not None:
+        if is_sponsored:
             return SponsoredEvent.objects.all()
         return ProposedTalkEvent.objects.all()
 
@@ -39,7 +39,7 @@ class TalkDetailAPIView(RetrieveAPIView):
         is_sponsored = self.request.GET.get('isSponsored')
         pk = self.kwargs["pk"]
         queryset = self.get_queryset()
-        if is_sponsored is not None:
+        if is_sponsored:
             return get_object_or_404(queryset, id=pk)
         return get_object_or_404(queryset, proposal_id=pk)
 

--- a/src/events/api/views.py
+++ b/src/events/api/views.py
@@ -154,6 +154,8 @@ class EventWrapper:
     def recording_policy(self) -> bool:
         if isinstance(self.obj, (KeynoteEvent, CustomEvent)):
             return True
+        elif isinstance(self.obj, SponsoredEvent):
+            return self.obj.recording_policy
         else:
             return self.obj.proposal.recording_policy
 

--- a/src/events/api/views.py
+++ b/src/events/api/views.py
@@ -55,23 +55,18 @@ class TutorialDetailAPIView(RetrieveAPIView):
     queryset = ProposedTutorialEvent.objects.all()
     serializer_class = serializers.TutorialDetailSerializer
 
+    def get_object(self):
+        pk = self.kwargs["pk"]
+        queryset = self.get_queryset()
+        return get_object_or_404(queryset, proposal_id=pk)
 
-class TutorialListAPIView(APIView):
+
+class TutorialListAPIView(ListAPIView):
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
 
-    def get(self, request):
-        tutorial_data = TutorialProposal.objects.filter_accepted()
-
-        response_data = {"tutorials": []}
-        for tutorial in tutorial_data:
-            response_data["tutorials"].append({
-                "title": tutorial.title,
-                "abstract": tutorial.abstract,
-                "tutorial_id": tutorial.id
-            })
-
-        return Response(response_data)
+    queryset = TutorialProposal.objects.filter_accepted()
+    serializer_class = serializers.TutorialListSerializer
 
 
 def _room_sort_key(room):

--- a/src/events/api/views.py
+++ b/src/events/api/views.py
@@ -7,6 +7,7 @@ from rest_framework.permissions import IsAuthenticated
 
 from django.conf import settings
 from django.db.models import Count
+from django.shortcuts import get_object_or_404
 
 from core.authentication import TokenAuthentication
 from events.models import (
@@ -22,8 +23,13 @@ class TalkDetailAPIView(RetrieveAPIView):
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
 
-    queryset = TalkProposal.objects.all()
+    queryset = ProposedTalkEvent.objects.all()
     serializer_class = serializers.TalkDetailSerializer
+
+    def get_object(self):
+        pk = self.kwargs["pk"]
+        queryset = self.get_queryset()
+        return get_object_or_404(queryset, proposal_id=pk)
 
 
 class TalkListAPIView(ListAPIView):

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -26,6 +26,7 @@ from core.models import EAWTextField, BigForeignKey
 class UserQueryset(models.QuerySet):
     """Custom queryset for User.
     """
+
     def get_valid_speakers(self):
         """Filter only valid speakers from the queryset.
 
@@ -39,6 +40,7 @@ class UserQueryset(models.QuerySet):
 class UserManager(BaseUserManager.from_queryset(UserQueryset)):
     """Custom manager for User.
     """
+
     def _create_user(self, email, password, **extra_fields):
         """Create and save an EmailUser with the given email and password.
 
@@ -255,10 +257,14 @@ class User(AbstractBaseUser, PermissionsMixin):
 
     @property
     def twitter_profile_url(self):
+        if not self.twitter_id:
+            return ""
         return 'https://twitter.com/{}'.format(self.twitter_id)
 
     @property
     def github_profile_url(self):
+        if not self.github_id:
+            return ""
         return 'https://github.com/{}'.format(self.github_id)
 
     def get_verification_key(self):


### PR DESCRIPTION
## Types of changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

The event API response format is defined based on the 2020 website since the frontend design of the 2021 website was WIP at the time, which does not perfectly meet the new spec.

1. Set the value of speaker profile URL to be an empty string if ID (including GitHub ID or Twitter ID) is not given.
2. Return the full URL of the speaker thumbnail (e.g. `<host>/media/XXX.jpg`) rather than just the path (e.g. `/media/XXX.jpg`).
3. Add/remove the fields to/from the response to meet the design spec.
4. Make Talk List/Detail APIs also retrieve the data of the sponsored events.

## API Response Format
### Talk List

- Current
```
[{
    "id": Number,
    "title": String,
    "category": String,
    "labels": String, // unused, always empty
    "speakers": [
        {
            "name": String,
            "facebook_profile_url": URL,
            "github_profile_url": URL,
            "twitter_profile_url": URL,
            "thumbnail_url": String (incomplete URL)
        },
        ...
    ],
}, ...]
```
- Modified Version
```
[{
    "id": Number,
    "title": String,
    "category": String,
    "speakers": [
        {
            "name": String,
            "thumbnail_url": URL
        },
        ...
    ],
    "is_sponsered": Boolean
}, ...]
```

### Talk Detail

- Current
```
{
	
    "title": String,
    "category": String,
    "language": String,
    "python_level": String,
    "recording_policy": Boolean,
    "abstract": String,
    "detailed_description": String,
    "slide_link": URL,
    "slido_embed_link": URL,
    "speakers": [
        {
            "facebook_profile_url": URL,
            "github_profile_url": URL,
            "name": String,
            "thumbnail_url": String (incomplete URL),
            "twitter_profile_url": Path
        },
        ...
    ]
}
```
- Modified Version
```
{
    "title": String,
    "category": String,
    "language": String,
    "python_level": String,
    "recording_policy": Boolean,
    "abstract": String,
    "detailed_description": String,
    "slide_link": URL,
    "slido_embed_link": URL,
    "speakers": [
        {
            "thumbnail_url": URL,
            "name": String,
            "github_profile_url": URL,
            "twitter_profile_url": URL,
            "facebook_profile_url": URL,
            "bio": String
        },
        ...
    ],
    "begin_time": Datetime,
    "end_time": Datetime,
    "is_remote": Boolean,
    "location": String,
    "is_sponsered": Boolean
}
```
P.S. Tutorial List & Tutorial Detail are similar to Talk ones but have no `is_sponsored`.
