### PR TITLE
chore: use sponsor name in en-us for open role api

### DIFF
--- a/src/sponsors/api/views.py
+++ b/src/sponsors/api/views.py
@@ -55,7 +55,7 @@ class JobAPIView(views.APIView):
                 logo = open_role.sponsor.logo
                 data[sponsor_id] = {
                     "sponsor_logo_url": logo.url if logo else '',
-                    "sponsor_name": open_role.sponsor.name,
+                    "sponsor_name": open_role.sponsor.name_en_us,
                     "jobs": [],
                 }
             data[sponsor_id]["jobs"].append({


### PR DESCRIPTION
## Types of changes

- [x] **Other (support GA data format)**

## Description

The sponsor name in open role API response is used by frontend and then passed to GA for counting the click on sponsor logo. The field is retrieved from db by the field `name` from `sponsor` model, but `name_en_us` is used in sponsor API, which cause the discrepancy between those two API and make it harder to joining those two metrics.

Update the open role API to unify the value of sponsor name to solve this issue.