### PR TITLE
fix(events/api/views.py): Let schedule API can return i18n str for keynote data

### DIFF
--- a/src/events/api/views.py
+++ b/src/events/api/views.py
@@ -1,4 +1,5 @@
 import collections
+from typing import List, Union
 
 from rest_framework.generics import RetrieveAPIView, ListAPIView
 from rest_framework.views import APIView
@@ -122,18 +123,26 @@ class EventWrapper:
         return TYPE_MAP[type(self.obj)]
 
     @property
-    def title(self) -> str:
+    def title(self) -> Union[str, dict]:
         if isinstance(self.obj, KeynoteEvent):
-            return self.obj.session_title
+            return {
+                'zh_hant': self.obj.session_title_zh_hant,
+                'en_us': self.obj.session_title_en_us,
+            }
         elif isinstance(self.obj, (ProposedTalkEvent, ProposedTutorialEvent)):
             return self.obj.proposal.title
         else:
             return self.obj.title
 
     @property
-    def speakers(self) -> list:
+    def speakers(self) -> Union[List[str], List[dict]]:
         if isinstance(self.obj, KeynoteEvent):
-            return [self.obj.speaker_name]
+            return [
+                {
+                    'zh_hant': self.obj.speaker_name_zh_hant,
+                    'en_us': self.obj.speaker_name_en_us,
+                }
+            ]
         if isinstance(self.obj, SponsoredEvent):
             return [self.obj.host.speaker_name]
         elif isinstance(self.obj, (ProposedTalkEvent, ProposedTutorialEvent)):


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
Let schedule API to return the keynote speaker's name and keynote title with i18n.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to http://localhost:8000/api/events/schedule/

## Expected behavior
Will see the keynote speaker's name, and the title is a dict with two keys: zh_hant, en_us.

## Related Issue
If applicable, refernce to the issue related to this pull request.

## More Information
**Screenshots**
If applicable, add screenshots to help explain your problem.

**Additional context**
Add any other context about the problem here. You may also want to refer
to [how to wirte the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)
