### PR TITLE
fix: add font color to show the count on the review voting panel

### DIFF
--- a/src/static/css/pages/_reviews.scss
+++ b/src/static/css/pages/_reviews.scss
@@ -17,6 +17,7 @@
 
         .panel-body{
             font-size: 30px;
+            color: #000;
         }
     }
 }


### PR DESCRIPTION
## Types of changes


- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
As mentioned in this issue #1069, can't see counts on the panel, because of the font color.
I give it with color `#000` for now.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Make some fake data on proposals and do the review.
2. Go to `http://0.0.0.0:8000/zh-hant/reviews/`.

## Expected behavior

The numbers should appear in the panel.

<img width="500" alt="Screen Shot 2022-04-10 at 10 31 33 PM" src="https://user-images.githubusercontent.com/65331756/162625933-6f4a0233-5f00-4360-b24d-ab4ec8439802.png">

## Related Issue
#1069
