### PR TITLE
fix(proposal): navbar color

### DIFF
--- a/src/static/css/vendors/bootstrap/_navs.scss
+++ b/src/static/css/vendors/bootstrap/_navs.scss
@@ -84,10 +84,12 @@
     > a {
       margin-right: 2px;
       line-height: $line-height-base;
-      border: 1px solid transparent;
+      border: 1px solid;
       border-radius: $border-radius-base $border-radius-base 0 0;
+      color: #fff;
       &:hover {
         border-color: $nav-tabs-link-hover-border-color $nav-tabs-link-hover-border-color $nav-tabs-border-color;
+        color: #555555;
       }
     }
 


### PR DESCRIPTION
## Types of changes

- [x] **Bugfix**

## Description

The color of the navbar on the proposal page is not clear:

<img width="610" alt="image" src="https://user-images.githubusercontent.com/24987826/167446702-112a5d61-82c9-495a-a315-8b4f00360b59.png">


change color as follow:

<img width="610" alt="image" src="https://user-images.githubusercontent.com/24987826/167446565-8f795ce9-1416-4bc2-81a6-80f95706f8d3.png">

