### PR TITLE
feat(events/api): add GET SpeechListByCategory views, urls and tests

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.test.html import parse_html
 from django.conf import settings
+from rest_framework.test import APIClient
 
 from proposals.models import TalkProposal
 from users.models import CocRecord
@@ -203,3 +204,8 @@ def accepted_talk_proposal(talk_proposal):
     talk_proposal.accepted = True
     talk_proposal.save()
     return talk_proposal
+
+
+@pytest.fixture
+def drf_api_client():
+    return APIClient()

--- a/src/events/api/urls.py
+++ b/src/events/api/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path('keynotes/', views.KeynoteEventListAPIView.as_view()),
     path('speeches/', views.SpeechListAPIView.as_view()),
     path('speeches/<str:event_type>/<int:pk>/', views.SpeechDetailAPIView.as_view()),
+    path('speeches/category/<str:category>', views.SpeechListByCategoryAPIView.as_view(), name="speeches-category"),
 ]

--- a/src/events/api/views.py
+++ b/src/events/api/views.py
@@ -21,18 +21,36 @@ from . import serializers
 
 
 class TalkListAPIView(ListAPIView):
-    queryset = ProposedTalkEvent.objects.all()
     serializer_class = serializers.TalkListSerializer
+
+    def get_queryset(self):
+        queryset = ProposedTalkEvent.objects.all()
+        category = self.kwargs.get('category')
+        if category is not None:
+            queryset = queryset.filter(proposal__category=category)
+        return queryset
 
 
 class SponsoredEventListAPIView(ListAPIView):
-    queryset = SponsoredEvent.objects.all()
     serializer_class = serializers.SponsoredEventListSerializer
+
+    def get_queryset(self):
+        queryset = SponsoredEvent.objects.all()
+        category = self.kwargs.get('category')
+        if category is not None:
+            queryset = queryset.filter(category=category)
+        return queryset
 
 
 class TutorialListAPIView(ListAPIView):
-    queryset = ProposedTutorialEvent.objects.all()
     serializer_class = serializers.TutorialListSerializer
+
+    def get_queryset(self):
+        queryset = ProposedTutorialEvent.objects.all()
+        category = self.kwargs.get('category')
+        if category is not None:
+            queryset = queryset.filter(proposal__category=category)
+        return queryset
 
 
 class SpeechListAPIView(APIView):
@@ -60,6 +78,20 @@ class SpeechListAPIView(APIView):
             return Response(data)
         else:
             raise Http404
+
+
+class SpeechListByCategoryAPIView(APIView):
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        data = []
+        for api_view in (SponsoredEventListAPIView, TalkListAPIView, TutorialListAPIView):
+            view = api_view.as_view()
+            event_data = view(request._request, *args, **kwargs).data
+            data.extend(event_data)
+
+        return Response(data)
 
 
 class TalkDetailAPIView(RetrieveAPIView):

--- a/src/events/tests/api/test_list_speeches.py
+++ b/src/events/tests/api/test_list_speeches.py
@@ -1,0 +1,53 @@
+import pytest
+
+from django.urls import reverse
+
+from core.models import Token
+from events.models import ProposedTalkEvent, ProposedTutorialEvent, SponsoredEvent
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        "WEB",
+        "EMBED",
+        "ADMIN",
+        "OTHER",
+        "TOOL",
+        "ML",
+        "LIBS",
+        "GAME",
+        "SCI",
+        "APPL",
+        "PRAC",
+        "COM",
+        "GRAPH",
+        "CORE",
+        "IOT",
+        "SEC",
+        "EDU",
+        "NLP",
+        "DATA",
+        "DB",
+        "FIN",
+        "TEST",
+        "WEB",
+        "INTNL",
+    ],
+)
+def test_list_speeches_by_category(category, bare_user, drf_api_client):
+    url = reverse("events:speeches-category", kwargs={"category": category})
+    token = Token.objects.get_or_create(user=bare_user)
+    drf_api_client.credentials(HTTP_AUTHORIZATION="Token " + str(token[0]))
+    response = drf_api_client.get(url)
+
+    for event in response.json():
+        assert event["category"] == category
+
+    assert (
+        len(response.json()) == ProposedTalkEvent.objects.filter(proposal__category=category).count() +
+        ProposedTutorialEvent.objects.filter(proposal__category=category).count() +
+        SponsoredEvent.objects.filter(category=category).count()
+    )
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**
- Add `api/events/speeches/category/<str:category>` endpoint and its related view and test

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Running GET `{API_HOST}/api/events/speeches/category/WEB` or others category like DATA, ML, etc.

## Expected behavior
List all events which have the corresponding category and have the same schema as the original Speech List API.

## Related Issue
#1080 
