### PR TITLE
fix: fix the statistic of the review counting

### DIFF
--- a/src/reviews/views.py
+++ b/src/reviews/views.py
@@ -114,13 +114,10 @@ class TalkProposalListView(ReviewableMixin, PermissionRequiredMixin, ListView):
             .values_list('vote')
             .annotate(count=Count('vote'))
         )
-        vote_count_pairs = stage_1_vote_count_pairs.union(stage_2_vote_count_pairs)
-        vote_mapping = collections.defaultdict(
-            (lambda: 0),
-            ((self.vote_keys[k], v)
-             for k, v in vote_count_pairs
-             if k in self.vote_keys),
-        )
+        vote_count_pairs = stage_1_vote_count_pairs.union(stage_2_vote_count_pairs, all=True)
+        vote_mapping = collections.defaultdict(int)
+        for k, v in vote_count_pairs:
+            vote_mapping[self.vote_keys[k]] += v
 
         context = super().get_context_data(**kwargs)
         context.update({


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
- The original counting for review is wrong is because the previous code didn't sum up the stage 1 and stage 2.

## Steps to Test This Pull Request
- Make some reviews in both stage 1 and stage 2, and try to review them in different stages.

## Expected behavior
- The total of 個人審查數據 should be the same as 已審查的演講提案
<img width="763" alt="Screen Shot 2022-06-29 at 5 49 40 PM" src="https://user-images.githubusercontent.com/65331756/176394500-2c072420-b608-4feb-b4ba-8a34f6db7f66.png">

## Related Issue
#1086 
