### PR TITLE
feat(swagger): add drf-yasg to automatically generate swagger in dev env

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -51,3 +51,6 @@ cssselect==1.1.0
 
 # PostgreSQL database adapter for the Python
 psycopg2-binary==2.8.5
+
+# Automated generation of real Swagger/OpenAPI 2.0 schemas from Django REST Framework code.
+drf-yasg==1.20.0

--- a/src/pycontw2016/settings/base.py
+++ b/src/pycontw2016/settings/base.py
@@ -103,7 +103,8 @@ THIRD_PARTY_APPS = (
     'sorl.thumbnail',
     'registry',
     'corsheaders',
-    'rest_framework'
+    'rest_framework',
+    'drf_yasg',
 )
 
 LOCAL_APPS = (

--- a/src/pycontw2016/urls.py
+++ b/src/pycontw2016/urls.py
@@ -13,16 +13,16 @@ from users.views import user_dashboard
 
 
 schema_view = get_schema_view(
-   openapi.Info(
-      title="Snippets API",
-      default_version='v1',
-      description="Test description",
-      terms_of_service="https://www.google.com/policies/terms/",
-      contact=openapi.Contact(email="contact@snippets.local"),
-      license=openapi.License(name="BSD License"),
-   ),
-   public=True,
-   permission_classes=(permissions.AllowAny,),
+    openapi.Info(
+        title="Snippets API",
+        default_version='v1',
+        description="Test description",
+        terms_of_service="https://www.google.com/policies/terms/",
+        contact=openapi.Contact(email="contact@snippets.local"),
+        license=openapi.License(name="BSD License"),
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
 )
 
 

--- a/src/pycontw2016/urls.py
+++ b/src/pycontw2016/urls.py
@@ -4,9 +4,26 @@ from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.views.i18n import set_language
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
 from core.views import error_page, flat_page, index
 from users.views import user_dashboard
+
+
+schema_view = get_schema_view(
+   openapi.Info(
+      title="Snippets API",
+      default_version='v1',
+      description="Test description",
+      terms_of_service="https://www.google.com/policies/terms/",
+      contact=openapi.Contact(email="contact@snippets.local"),
+      license=openapi.License(name="BSD License"),
+   ),
+   public=True,
+   permission_classes=(permissions.AllowAny,),
+)
 
 
 urlpatterns = i18n_patterns(
@@ -45,3 +62,8 @@ urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 if settings.DEBUG:
     import debug_toolbar
     urlpatterns += [url(r'^__debug__/', include(debug_toolbar.urls))]
+    urlpatterns += [
+        url(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+        url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+        url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+    ]


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [x] **New feature**

## Description
**Describe what the change is**
Add `drf-yasg` to generate swagger from drf automatically.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Running your server in local environment
2. Go to page `http://0.0.0.0:8000/swagger/` or `http://0.0.0.0:8000/redoc`


