### PR TITLE
feat(settings.production.base): set GS_DEFAULT_ACL to publicRead

### DIFF
--- a/src/pycontw2016/settings/production/base.py
+++ b/src/pycontw2016/settings/production/base.py
@@ -139,3 +139,4 @@ GS_CREDENTIALS = service_account.Credentials.from_service_account_file(
     os.path.join(BASE_DIR, "google-cloud-storage.json")
 )
 GS_BUCKET_NAME = "pycontw-static"
+GS_DEFAULT_ACL = "publicRead" # make files return as public, non-expiring url since we use static site that will fetch the files directly


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [x] **New feature**

## Steps to Produce this PR
1. put your `google-cloud-storage.json` under src/
2. (Workaround) Rewrite https://github.com/pycontw/pycon.tw/blob/master/src/sponsors/models.py#L14 to `return default_storage if False else GoogleCloudStorage()`
3. Copy L138 to L142 in https://github.com/pycontw/pycon.tw/pull/1108/files#diff-2ceb691b10b9d00dad55f62e98e5bf2916af93f9138538355a20604d2650ea8dR138-R142 to `pycontw2016.base.py`
4. Run `docker-compose -f ./docker-compose-dev.yml up`

## Description
**Describe what the change is**
You don't need to explain HOW you change the code. Your code, including comments in the code should explicitly
self-describe enough about how you change the code.

Setting `GS_DEFAULT_ACL` to `publicRead` so that the return image URL would exclude the expiration period.

## Expected behavior
The retrieved image url would not contain the expiration period.

## Related Issue
closes #1107 

## More Information
**Screenshots**
<img width="1222" alt="image" src="https://user-images.githubusercontent.com/18432820/207220020-13618035-f7cf-4293-bd92-b168cd614707.png">
