### PR TITLE
Adjust color setting of review edit view

### DIFF
--- a/src/static/css/pages/_proposals.scss
+++ b/src/static/css/pages/_proposals.scss
@@ -122,7 +122,7 @@ body.dashboard{
                         display: inline-block;
                         text-decoration: none;
                         padding: 0 0.5em;
-                        color: $diff-text-color;
+                        color: #3c0970;
                     }
                     del {
                         background-color: lighten($brand-danger, 33.5%);
@@ -146,7 +146,7 @@ body.dashboard{
                     }
                     ins > ins {
                         padding: 0;
-                        background-color: $diff-text-bg-color;
+                        background-color: #eba292;
                     }
                 }
                 .markdown-field {

--- a/src/static/css/pages/_proposals.scss
+++ b/src/static/css/pages/_proposals.scss
@@ -122,7 +122,7 @@ body.dashboard{
                         display: inline-block;
                         text-decoration: none;
                         padding: 0 0.5em;
-                        color: $text-color;
+                        color: $diff-text-color;
                     }
                     del {
                         background-color: lighten($brand-danger, 33.5%);
@@ -146,7 +146,7 @@ body.dashboard{
                     }
                     ins > ins {
                         padding: 0;
-                        background-color: lighten($brand-success, 20%);
+                        background-color: $diff-text-bg-color;
                     }
                 }
                 .markdown-field {

--- a/src/static/pycontw-2023/_includes/_bootstrap-variables.scss
+++ b/src/static/pycontw-2023/_includes/_bootstrap-variables.scss
@@ -32,6 +32,10 @@ $brand-primary:         #e8a4e9 !default;
 // //** Global text color on `<body>`.
 $text-color:            #f0ebf5 !default;
 
+// //** Color setting for review edit view.
+$diff-text-color:       #3c0970 !default;
+$diff-text-bg-color:    #eba292 !default;
+
 // //** Global textual link color.
 // $link-color:            $brand-primary !default;
 // //** Link hover color set via `darken()` function.

--- a/src/static/pycontw-2023/_includes/_bootstrap-variables.scss
+++ b/src/static/pycontw-2023/_includes/_bootstrap-variables.scss
@@ -32,10 +32,6 @@ $brand-primary:         #e8a4e9 !default;
 // //** Global text color on `<body>`.
 $text-color:            #f0ebf5 !default;
 
-// //** Color setting for review edit view.
-$diff-text-color:       #3c0970 !default;
-$diff-text-bg-color:    #eba292 !default;
-
 // //** Global textual link color.
 // $link-color:            $brand-primary !default;
 // //** Link hover color set via `darken()` function.


### PR DESCRIPTION
## Types of changes
- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
Adjusted the text color of compare tab at reveiw edit view and the background color of the changed content for increase the color contrast.

## More Information
![image](https://github.com/pycontw/pycon.tw/assets/76610430/eda0b024-6b3c-4a28-a38a-71eaedf025f1)

