### PR TITLE
feat(sponsor): make sponsor en name as a required field

### DIFF
--- a/src/sponsors/translation.py
+++ b/src/sponsors/translation.py
@@ -5,6 +5,7 @@ from .models import Sponsor, OpenRole
 
 class SponsorTranslationOptions(TranslationOptions):
     fields = ('name', 'intro', 'subtitle',)
+    required_languages = {'default': ('name',)}
 
 
 class OpenRoleTranslationOptions(TranslationOptions):


### PR DESCRIPTION
## Types of changes

- [x] **New feature**

## Description

en-us name field of the sponsor model should be required as it's the field that allows us to differentiate sponsor info from the GA click count events. (see discord discussion thread [here](https://discord.com/channels/752904426057892052/1138015073126846504/1138035759379652669))

Saving sponsor data without an en-us name will be blocked with this PR.
<img width="1180" alt="image" src="https://github.com/pycontw/pycon.tw/assets/24987826/9b8ac3c0-1905-431c-a6fa-5a5ff5574d82">
