### PR TITLE
feat(ccip): let session start/end time follow local timezone

### DIFF
--- a/src/ccip/views.py
+++ b/src/ccip/views.py
@@ -1,4 +1,5 @@
 import operator
+from datetime import timezone, timedelta
 
 from django.http import JsonResponse
 from django.templatetags.static import static
@@ -166,11 +167,15 @@ def _transform_session(request, event, type_key, info_getter):
         for speaker in event_info.speakers
     ]
 
+    LOCAL_TIMEZONE = timezone(offset=timedelta(hours=8))
+    # Explicitly show the local timezone used by OPass(CCIP)
+    # to avoid iOS device showing UTC+0 time without changing it to local time
+    # https://github.com/CCIP-App/CCIP-iOS/issues/54
     session = {
         'id': f'{type_key}-{event_info.pk}',
         'type': type_key,
-        'start': event.begin_time.value.isoformat() if event.begin_time else None,
-        'end': event.end_time.value.isoformat() if event.end_time else None,
+        'start': event.begin_time.value.astimezone(LOCAL_TIMEZONE).isoformat() if event.begin_time else None,
+        'end': event.end_time.value.astimezone(LOCAL_TIMEZONE).isoformat() if event.end_time else None,
         'slide': event_info.slide_link,
         'speakers': [speaker['id'] for speaker in speakers],
         'tags': [tag['id'] for tag in tags],


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies


- [x] **New feature**


## Description
* let session start/end time follow local timezone

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to http://localhost:8000/ccip/


## Expected behavior
<img width="1433" alt="image" src="https://github.com/pycontw/pycon.tw/assets/18432820/f51fb07f-658e-4633-a769-50f7568a235a">

## Related Issue
#1148 

## More Information
**Screenshots**
If applicable, add screenshots to help explain your problem.

**Additional context**
Add any other context about the problem here. You may also want to refer
to [how to wirte the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)
