### PR TITLE
build(dockerfile): enhanced production dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,35 @@
-FROM python:3.6-buster
+# [Node Stage to get node_modolues and node dependencies]
+FROM node:8.16.0-buster-slim as node_stage
+
+COPY ./yarn.lock yarn.lock
+COPY ./package.json package.json
+
+RUN npm install -g yarn
+RUN yarn install --dev --frozen-lockfile  \
+ && rm -rf $HOME/.cache/yarn/*
+
+
+# [Python Stage for Django web server]
+FROM python:3.6-slim-buster as python_stage
+
+COPY --from=node_stage /node_modules /usr/local/lib/node_modules
+COPY --from=node_stage /usr/local/bin/node /usr/local/bin/node
 
 ENV PYTHONUNBUFFERED 1
 ENV BASE_DIR /usr/local
 ENV APP_DIR $BASE_DIR/app
 
-ENV NVM_INSTALLER_URL https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh
-ENV NVM_DIR $BASE_DIR/nvm
-ENV YARN_VERSION 1.15.2-1
-ENV NODE_VERSION 8.16.0
+# make nodejs accessible and executable globally
+ENV NODE_PATH /usr/local/lib/node_modules/
+ENV PATH /usr/local/bin:$PATH
 
-# make nodejs and yarn accessible and executable globally
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 # Add bin directory used by `pip install --user`
-ENV PATH "/home/docker/.local/bin:${PATH}"
+ENV PATH /home/docker/.local/bin:$PATH
 
 # Infrastructure tools
 # gettext is used for django to compile .po to .mo files.
 RUN apt-get update
-RUN apt-get install apt-utils -y
-RUN apt-get update
-RUN apt-get install gettext python3-pip -y
-
-# Install Node and Yarn from upstream
-RUN curl -o- $NVM_INSTALLER_URL | bash \
- && . $NVM_DIR/nvm.sh \
- && nvm install $NODE_VERSION \
- && nvm alias default $NODE_VERSION \
- && nvm use default \
- && nvm --version \
- && npm install -g yarn \
- && yarn --version
+RUN apt-get install gettext libpq-dev gcc -y
 
 # APP directory setup
 RUN adduser --system --disabled-login docker \
@@ -38,20 +37,15 @@ RUN adduser --system --disabled-login docker \
  && chown -R docker:nogroup "$BASE_DIR" "$APP_DIR"
 
 USER docker
-WORKDIR $APP_DIR
 
 # Only copy and install requirements to improve caching between builds
 # Install Python dependencies
 COPY --chown=docker:nogroup ./requirements $APP_DIR/requirements
 RUN pip3 install --user -r "$APP_DIR/requirements/production.txt" \
  && rm -rf $HOME/.cache/pip/*
-# Install Javascript dependencies
-COPY --chown=docker:nogroup ./package.json $APP_DIR/package.json
-COPY --chown=docker:nogroup ./yarn.lock $APP_DIR/yarn.lock
-RUN yarn install --dev --frozen-lockfile \
- && rm -rf $HOME/.cache/yarn/*
+
 # Finally, copy all the project files along with source files
-COPY --chown=docker:nogroup . $APP_DIR
+COPY --chown=docker:nogroup ./ $APP_DIR
 
 WORKDIR $APP_DIR/src
 VOLUME $APP_DIR/src/media

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -4,6 +4,9 @@ FROM node:8.16.0-buster-slim as node_stage
 COPY ./yarn.lock yarn.lock
 COPY ./package.json package.json
 
+RUN apt-get update
+RUN apt-get install python-pip -y
+
 RUN npm install -g yarn
 RUN yarn install --dev --frozen-lockfile
 
@@ -18,13 +21,15 @@ COPY --from=node_stage /usr/local/bin/node /usr/local/bin/node
 ENV PYTHONUNBUFFERED 1
 ENV BASE_DIR /usr/local
 
-# make node accessible and executable globally
-ENV PATH /usr/local/bin:$PATH
-
 # Infrastructure tools
 # gettext is used for django to compile .po to .mo files.
 RUN apt-get update
-RUN apt-get install gettext gcc -y
+RUN apt-get install -y \
+    libpq-dev \
+    gcc \
+    zlib1g-dev \
+    libjpeg62-turbo-dev \
+    gettext
 
 # Only copy and install requirements to improve caching between builds
 # Install Python dependencies

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,43 +1,35 @@
-FROM python:3.6-slim-buster
+# [Node Stage to get node_modolues and node dependencies]
+FROM node:8.16.0-buster-slim as node_stage
 
-ENV PYTHONUNBUFFERED 1
+COPY ./yarn.lock yarn.lock
+COPY ./package.json package.json
+
+RUN npm install -g yarn
+RUN yarn install --dev --frozen-lockfile
+
+# [Python Stage for Django web server]
+FROM python:3.6-slim-buster as python_stage
+
 WORKDIR /app
 
+COPY --from=node_stage /node_modules ./node_modules
+COPY --from=node_stage /usr/local/bin/node /usr/local/bin/node
+
+ENV PYTHONUNBUFFERED 1
 ENV BASE_DIR /usr/local
 
-ENV NVM_INSTALLER_URL https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh
-ENV NVM_DIR $BASE_DIR/nvm
-ENV YARN_VERSION 1.15.2-1
-ENV NODE_VERSION 8.16.0
-
-# make nodejs and yarn accessible and executable globally
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+# make node accessible and executable globally
+ENV PATH /usr/local/bin:$PATH
 
 # Infrastructure tools
 # gettext is used for django to compile .po to .mo files.
 RUN apt-get update
-RUN apt-get install apt-utils -y
-RUN apt-get update
-RUN apt-get install gettext python3-pip -y
+RUN apt-get install gettext gcc -y
 
-# Install Node and Yarn from upstream
-RUN curl -o- $NVM_INSTALLER_URL | bash \
-    && . $NVM_DIR/nvm.sh \
-    && nvm install $NODE_VERSION \
-    && nvm alias default $NODE_VERSION \
-    && nvm use default \
-    && nvm --version \
-    && npm install -g yarn \
-    && yarn --version
-
+# Only copy and install requirements to improve caching between builds
 # Install Python dependencies
 COPY ./requirements ./requirements
 RUN pip3 install -r ./requirements/dev.txt
-
-# # Install Javascript dependencies
-COPY ./package.json ./package.json
-COPY ./yarn.lock ./yarn.lock
-RUN yarn install --dev --frozen-lockfile
 
 # for entry point
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh


### PR DESCRIPTION
## Types of changes
- [ ] **Bugfix**
- [ ] **New feature**
- [x] **Refactoring** Dockerfile
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
Use multi-stage feature on Docker to enable easy-read and better maintenance for Dockerfile

Two stages: node_stage and python_stage
node_stage: 
- handling node_modules and node **executable**, by using multi-stage with `FROM`, we can specify docker image taf and get the node run-time with no extra works (nvm and hardcoded download link)
- use buster-slim variant

python_stage:
- handling Python environment and web server instructions
- using slim-buster variant
- need to manually install libpq and GCC for pyscopg2 and uwsgi as we downsize from buster to slim-buster

Notes:
- need to align image variant to {size-variant}-{debian-variant} to make node executable executable (For example, both node_stage and python_stage needs to be **SLIM** **BUSTER**)

## Steps to Test This Pull Request
- Same

## Expected behavior
Size reduced up to 50% and more

from the staging environment, test results are as follow:
`pycontw-2023_web-enhanced-dockerfile          latest                e620e4f466ac        24 seconds ago       626MB`
`pycontw-2023_web                              latest                11ff9f780b7d        2 weeks ago          1.56GB`

closes #1139 