### PR TITLE
fix `/usr/local/app/node_modules/.bin/node-sass: not found` 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,15 @@ RUN yarn install --dev --frozen-lockfile  \
 # [Python Stage for Django web server]
 FROM python:3.6-slim-buster as python_stage
 
-COPY --from=node_stage /node_modules /usr/local/lib/node_modules
-COPY --from=node_stage /usr/local/bin/node /usr/local/bin/node
-
 ENV PYTHONUNBUFFERED 1
 ENV BASE_DIR /usr/local
 ENV APP_DIR $BASE_DIR/app
 
+COPY --from=node_stage /node_modules $APP_DIR/node_modules
+COPY --from=node_stage /usr/local/bin/node /usr/local/bin/node
+
 # make nodejs accessible and executable globally
-ENV NODE_PATH /usr/local/lib/node_modules/
+ENV NODE_PATH $APP_DIR/node_modules/
 ENV PATH /usr/local/bin:$PATH
 
 # Add bin directory used by `pip install --user`


### PR DESCRIPTION
fix node_modules path for production dockerfile

## Types of changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**
related to #1156 
After #1151 , the node_modules are misplaced. Should be in `usr/local/app`.

## Steps to Test This Pull Request
Re-build image using updated `Dockerfile`

## Expected behavior
No longer need a manual fix for node_modules path

## Related Issue
#1156 

## More Information
Run and tested in staging vm
