### PR TITLE
feat: adjust conference date to 2024

### DIFF
--- a/src/core/choices.py
+++ b/src/core/choices.py
@@ -38,10 +38,10 @@ PYTHON_LVL_CHOICES = (
 )
 
 PREFER_TIME_CHOICES = (
-    ('DAY_ONE_MORNING', _('Day 1, September 2nd, 2023 Morning')),
-    ('DAY_ONE_AFTERNOON', _('Day 1, September 2nd, 2023 Afternoon')),
-    ('DAY_TWO_MORNING', _('Day 2, September 3rd, 2023 Morning')),
-    ('DAY_TWO_AFTERNOON', _('Day 2, September 3rd, 2023 Afternoon')),
+    ('DAY_ONE_MORNING', _('Day 1, September 21th, 2024 Morning')),
+    ('DAY_ONE_AFTERNOON', _('Day 1, September 21th, 2024 Afternoon')),
+    ('DAY_TWO_MORNING', _('Day 2, September 22th, 2024 Morning')),
+    ('DAY_TWO_AFTERNOON', _('Day 2, September 22th, 2024 Afternoon')),
 )
 
 RECORDING_POLICY_CHOICES = (

--- a/src/core/choices.py
+++ b/src/core/choices.py
@@ -38,10 +38,10 @@ PYTHON_LVL_CHOICES = (
 )
 
 PREFER_TIME_CHOICES = (
-    ('DAY_ONE_MORNING', _('Day 1, September 21th, 2024 Morning')),
-    ('DAY_ONE_AFTERNOON', _('Day 1, September 21th, 2024 Afternoon')),
-    ('DAY_TWO_MORNING', _('Day 2, September 22th, 2024 Morning')),
-    ('DAY_TWO_AFTERNOON', _('Day 2, September 22th, 2024 Afternoon')),
+    ('DAY_ONE_MORNING', _('Day 1, September 21st, 2024 Morning')),
+    ('DAY_ONE_AFTERNOON', _('Day 1, September 21st, 2024 Afternoon')),
+    ('DAY_TWO_MORNING', _('Day 2, September 22nd, 2024 Morning')),
+    ('DAY_TWO_AFTERNOON', _('Day 2, September 22nd, 2024 Afternoon')),
 )
 
 RECORDING_POLICY_CHOICES = (

--- a/src/locale/en_US/LC_MESSAGES/django.po
+++ b/src/locale/en_US/LC_MESSAGES/django.po
@@ -214,20 +214,20 @@ msgid "Experienced"
 msgstr "Experienced"
 
 #: core/choices.py:41
-msgid "Day 1, September 2nd, 2023 Morning"
-msgstr "Day 1, September 2nd, 2023 Morning with Taiwan Standard Time(UTC+8)"
+msgid "Day 1, September 21th, 2024 Morning"
+msgstr "Day 1, September 21th, 2024 Morning with Taiwan Standard Time(UTC+8)"
 
 #: core/choices.py:42
-msgid "Day 1, September 2nd, 2023 Afternoon"
-msgstr "Day 1, September 2nd, 2023 Afternoon with Taiwan Standard Time(UTC+8)"
+msgid "Day 1, September 21th, 2024 Afternoon"
+msgstr "Day 1, September 21th, 2024 Afternoon with Taiwan Standard Time(UTC+8)"
 
 #: core/choices.py:43
-msgid "Day 2, September 3rd, 2023 Morning"
-msgstr "Day 2, September 3rd, 2023 Morning with Taiwan Standard Time(UTC+8)"
+msgid "Day 2, September 22th, 2024 Morning"
+msgstr "Day 2, September 22th, 2024 Morning with Taiwan Standard Time(UTC+8)"
 
 #: core/choices.py:44
-msgid "Day 2, September 3rd, 2023 Afternoon"
-msgstr "Day 2, September 3rd, 2023 Afternoon with Taiwan Standard Time(UTC+8)"
+msgid "Day 2, September 22th, 2024 Afternoon"
+msgstr "Day 2, September 22th, 2024 Afternoon with Taiwan Standard Time(UTC+8)"
 
 #: core/choices.py:48 core/choices.py:53 core/choices.py:58 core/choices.py:63
 #: core/choices.py:68 reviews/models.py:122 reviews/models.py:137

--- a/src/locale/en_US/LC_MESSAGES/django.po
+++ b/src/locale/en_US/LC_MESSAGES/django.po
@@ -214,20 +214,20 @@ msgid "Experienced"
 msgstr "Experienced"
 
 #: core/choices.py:41
-msgid "Day 1, September 21th, 2024 Morning"
-msgstr "Day 1, September 21th, 2024 Morning with Taiwan Standard Time(UTC+8)"
+msgid "Day 1, September 21st, 2024 Morning"
+msgstr "Day 1, September 21st, 2024 Morning with Taiwan Standard Time(UTC+8)"
 
 #: core/choices.py:42
-msgid "Day 1, September 21th, 2024 Afternoon"
-msgstr "Day 1, September 21th, 2024 Afternoon with Taiwan Standard Time(UTC+8)"
+msgid "Day 1, September 21st, 2024 Afternoon"
+msgstr "Day 1, September 21st, 2024 Afternoon with Taiwan Standard Time(UTC+8)"
 
 #: core/choices.py:43
-msgid "Day 2, September 22th, 2024 Morning"
-msgstr "Day 2, September 22th, 2024 Morning with Taiwan Standard Time(UTC+8)"
+msgid "Day 2, September 22nd, 2024 Morning"
+msgstr "Day 2, September 22nd, 2024 Morning with Taiwan Standard Time(UTC+8)"
 
 #: core/choices.py:44
-msgid "Day 2, September 22th, 2024 Afternoon"
-msgstr "Day 2, September 22th, 2024 Afternoon with Taiwan Standard Time(UTC+8)"
+msgid "Day 2, September 22nd, 2024 Afternoon"
+msgstr "Day 2, September 22nd, 2024 Afternoon with Taiwan Standard Time(UTC+8)"
 
 #: core/choices.py:48 core/choices.py:53 core/choices.py:58 core/choices.py:63
 #: core/choices.py:68 reviews/models.py:122 reviews/models.py:137

--- a/src/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/src/locale/zh_Hant/LC_MESSAGES/django.po
@@ -221,20 +221,20 @@ msgid "Experienced"
 msgstr "進階"
 
 #: core/choices.py:41
-msgid "Day 1, September 2nd, 2023 Morning"
-msgstr "第一天(2023/09/02)早上"
+msgid "Day 1, September 21st, 2024 Morning"
+msgstr "第一天(2024/09/21)早上"
 
 #: core/choices.py:42
-msgid "Day 1, September 2nd, 2023 Afternoon"
-msgstr "第一天(2023/09/02)下午"
+msgid "Day 1, September 21st, 2024 Afternoon"
+msgstr "第一天(2024/09/21)下午"
 
 #: core/choices.py:43
-msgid "Day 2, September 3rd, 2023 Morning"
-msgstr "第二天(2023/09/03)早上"
+msgid "Day 2, September 22nd, 2024 Morning"
+msgstr "第二天(2024/09/22)早上"
 
 #: core/choices.py:44
-msgid "Day 2, September 3rd, 2023 Afternoon"
-msgstr "第二天(2023/09/03)下午"
+msgid "Day 2, September 22nd, 2024 Afternoon"
+msgstr "第二天(2024/09/22)下午"
 
 #: core/choices.py:48 core/choices.py:53 core/choices.py:58 core/choices.py:63
 #: core/choices.py:68 reviews/models.py:122 reviews/models.py:137

--- a/src/pycontw2016/settings/base.py
+++ b/src/pycontw2016/settings/base.py
@@ -325,8 +325,8 @@ TALK_PROPOSAL_DURATION_CHOICES = (
 )
 
 EVENTS_DAY_NAMES = collections.OrderedDict([
-    (datetime.date(2024, 9, 2), _('Day 1')),
-    (datetime.date(2024, 9, 3), _('Day 2')),
+    (datetime.date(2024, 9, 21), _('Day 1')),
+    (datetime.date(2024, 9, 22), _('Day 2')),
 ])
 
 SCHEDULE_REDIRECT_URL = None


### PR DESCRIPTION
update date in 2023 to 2024

## Types of changes

- [ x ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
**Describe what the change is**
Current options are outdated in proposal system. latest conference dates have to be updated to 
Day1: 2024/9/21
Day2: 2024/9/22

screenshot:
![image](https://github.com/pycontw/pycon.tw/assets/26858727/7079656f-ebd1-4fd9-83f3-e83b5b6cfb11)

## Related Issue
#1163

## More Information
**Screenshots**
If applicable, add screenshots to help explain your problem.

**Additional context**
Refer to: 
https://github.com/pycontw/pycon.tw/pull/1120
