### PR TITLE
[Email Feature] add relay smtp server configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,13 @@
 version: "3.5"
 services:
+  mailserver:
+    container_name: relay-smtp-mail-server
+    image: boky/postfix
+    environment:
+      ALLOWED_SENDER_DOMAINS: ${ALLOWED_SENDER_DOMAINS}
+      RELAYHOST: "smtp-relay.gmail.com:25"
+    networks:
+      - network
   web:
     build: .
     container_name: pycontw-2024

--- a/document/deploy_docker_prod.md
+++ b/document/deploy_docker_prod.md
@@ -21,10 +21,11 @@ There are four configurations that must be set when running the container.
  * `DATABASE_URL` specifies how to connect to the database (in the URL form
    e.g. `postgres://username:password@host_or_ip:5432/database_name`)
  * `EMAIL_URL` specifies how to connect to the mail server
-   (e.g. `smtp+tls://username:password@host_or_ip:25`)
+   (e.g. `smtp+tls://username:password@host_or_ip:25`, `smtp://host_or_ip:587` for local smtp server)
  * `DSN_URL` specify how to connect to Sentry error reporting service
    (e.g. `https://key@sentry.io/project`), please refer to
    [Sentry's documentation on how to obtain Data Source Name](https://docs.sentry.io/error-reporting/quickstart/?platform=python)
+ * (optional) `ALLOWED_SENDER_DOMAINS` - Could be `python.tw` if we [route outgoing SMTP relay messages through Google](https://support.google.com/a/answer/2956491?hl=en)
  * (optional) `GTM_TRACK_ID`
  * (optional) `SLACK_WEBHOOK_URL`
 

--- a/src/pycontw2016/settings/production/base.py
+++ b/src/pycontw2016/settings/production/base.py
@@ -95,16 +95,16 @@ MIDDLEWARE += (
     'SentryResponseErrorIdMiddleware',
 )
 
-EMAIL_BACKEND = env.email_url()['EMAIL_BACKEND']
-EMAIL_HOST = env.email_url()['EMAIL_HOST']
-EMAIL_HOST_PASSWORD = env.email_url()['EMAIL_HOST_PASSWORD']
-EMAIL_HOST_USER = env.email_url()['EMAIL_HOST_USER']
-EMAIL_PORT = env.email_url()['EMAIL_PORT']
-EMAIL_USE_TLS = env.email_url()['EMAIL_USE_TLS']
+EMAIL_BACKEND = env.email_url().get('EMAIL_BACKEND')
+EMAIL_HOST = env.email_url().get('EMAIL_HOST')
+EMAIL_HOST_PASSWORD = env.email_url().get('EMAIL_HOST_PASSWORD')
+EMAIL_HOST_USER = env.email_url().get('EMAIL_HOST_USER')
+EMAIL_PORT = env.email_url().get('EMAIL_PORT')
+EMAIL_USE_TLS = env.email_url().get('EMAIL_USE_TLS')
 
 DEFAULT_FROM_EMAIL = SERVER_EMAIL = '{name} <{addr}>'.format(
     name='PyCon Taiwan',
-    addr='web@pycon.tw',
+    addr='no-reply@python.tw',
 )
 
 # Securiy related settings


### PR DESCRIPTION
# feat(smtp-relay): add relay smtp server configuration

## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
目前 `dev@pycon.tw` 的寄信流程處於過渡期，目前希望透過 `*@python.tw` 取代 `dev@pycon.tw` 來寄信。
當中，Google Workspace (`python.tw`) 的架構需要在 server (staging vm + prod vm) 架設 SMTP server 來 route email message 至 google relay server。因此增加了一個 docker service 來達成此目的。

## Steps to Test This Pull Request
Steps to reproduce the behavior （只適用於 production environment）:
前置作業：
* workspace 系統管理員依照 [Google Admin Console 設定](https://support.google.com/a/answer/2956491?hl=en#zippy=%2Cpostfix) 輸入
* Allowed Senders - Only addresses in my domains
* Authentication - IP list (輸入 prod vm + staging vm 的 public IP)
* TLS checked

Server 端修改
1. `.env` 需要新增 `ALLOWED_SENDER_DOMAINS=python.tw`
2.  修改 `.env` 的 `EMAIL_URL` 至 `smtp://mailserver:587` (local service 會轉傳，不是直接透過 google smtp 了)
3.  `docker-compose pull`
4.  `docker-compose up`

## Expected behavior
* 可以使用任意 `@python.tw` address 當作 sender 發信。
