### PR TITLE
fix(static): proposal system bg img is not shown when local dev

### DIFF
--- a/src/static/css/pages/_proposals.scss
+++ b/src/static/css/pages/_proposals.scss
@@ -1,7 +1,7 @@
 body.dashboard{
     font-weight: 400;
     background: #1A1A30;
-    background-image: url(/prs/static/pycontw-2023/assets/bg-dashboard.svg);
+    background-image: url('../pycontw-2024/assets/bg-dashboard.svg');
 
     p.welcome{
         font-size: 21px;


### PR DESCRIPTION
## Types of changes

- [x] **Bugfix**

## Description

The background image is not shown when dev with the local server (but appears on staging/production).

## Steps to Test This Pull Request

1. run local server
2. bg image not shown and has error messages

## Expected behavior

no error msg and the background image has displayed
