### PR TITLE
fix(proposal): 404 error for co-speaker

### DIFF
--- a/src/templates/default/users/_includes/dashboard_cospeaking_proposal_table.html
+++ b/src/templates/default/users/_includes/dashboard_cospeaking_proposal_table.html
@@ -34,7 +34,7 @@
       <td>{{ speaker_info.get_status_display }}</td>
       <td>
         <form method="post"
-            action="{% url 'additional_speaker_set_status' pk=speaker_info.pk %}">
+            action="{% url 'additional_speaker_set_status' pk=speaker_info.pk %}" hidden>
           {% csrf_token %}
           {% if speaker_info.status != 'accepted' %}
           <button type="submit" name="status" value="accepted"

--- a/src/templates/default/users/_includes/dashboard_cospeaking_proposal_table.html
+++ b/src/templates/default/users/_includes/dashboard_cospeaking_proposal_table.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<table class="proposals-table table table-striped table-hover">
+<table class="proposals-table table table-responsive">
   <thead>
     <tr>
         <th class="proposal-title">{% trans 'Title' %}</th>


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
Resolve 404 error and strange style of table after co-speaker pressed accept/decline during reviewing stage, which "SLUG.proposals.editable" is false.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Create 2 users: main speaker A and co speaker B.
2. Go to Django admin and set to cfp stage as [doc](https://github.com/pycontw/pycon.tw/tree/master/src/reviews)
3. Sign in as speaker A into http://localhost:8000/en-us/dashboard/ and create a new proposal
4. Go to Django admin and set to review stage. 
5. Found the proposal from speaker A and add B in "Additional Speakers" table.
6. Sign in as speaker B into http://localhost:8000/en-us/dashboard/ and press "accept" and "decline" on the request. 
7. See error if page 404 shows up.

## Expected behavior
404 happened in Step[7] disappear.

## More Information
**Screenshots**
<img width="475" alt="image" src="https://github.com/pycontw/pycon.tw/assets/26858727/6d05ef36-828c-4296-9cbd-3bbca56614e9">

