### PR TITLE
fix(category): fix category filtering not working when order by other…

### DIFF
--- a/src/templates/default/reviews/_includes/proposal_table.html
+++ b/src/templates/default/reviews/_includes/proposal_table.html
@@ -4,9 +4,9 @@
 	<tr>
 		{% if not verdict %}
 			<th width="1%">
-				<a {% if ordering == 'review__count' %}class="active asc" href="?order=-count&category={{ category }}"
-					 {% elif ordering == '-review__count' %}class="active desc" href="?order=count&category={{ category }}"
-					 {% else %}href="?order=count&category={{ category }}"{% endif %}>
+				<a {% if ordering == 'review__count' %}class="active asc" href="?order=-count&category={{ category|default:'' }}"
+					 {% elif ordering == '-review__count' %}class="active desc" href="?order=count&category={{ category|default:'' }}"
+					 {% else %}href="?order=count&category={{ category|default:'' }}"{% endif %}>
 					{% trans 'Reviewed' %}
 					<i class="fa fa-sort fa-lg"></i>
 					<i class="fa fa-sort-asc fa-lg"></i>
@@ -15,8 +15,8 @@
 			</th>
 		{% endif %}
 		<th class="proposal-title">
-			<a {% if ordering == 'title' %}class="active asc" href="?order=-title&category={{ category }}"
-				 {% elif ordering == '-title' %}class="active desc" href="?order=title&category={{ category }}"{% else %}href="?order=title&category={{ category }}"{% endif %}>
+			<a {% if ordering == 'title' %}class="active asc" href="?order=-title&category={{ category|default:'' }}"
+				 {% elif ordering == '-title' %}class="active desc" href="?order=title&category={{ category|default:'' }}"{% else %}href="?order=title&category={{ category|default:'' }}"{% endif %}>
 				{% trans 'Title' %}
 				<i class="fa fa-sort fa-lg"></i>
 				<i class="fa fa-sort-asc fa-lg"></i>
@@ -24,9 +24,9 @@
 			</a>
 		</th>
 		<th width="1%" class="hidden-md hidden-sm hidden-xs">
-			<a {% if ordering == 'language' %}class="active asc" href="?order=-lang&category={{ category }}"
-				 {% elif ordering == '-language' %}class="active desc" href="?order=lang&category={{ category }}"
-				 {% else %}href="?order=lang&category={{ category }}"{% endif %}>
+			<a {% if ordering == 'language' %}class="active asc" href="?order=-lang&category={{ category|default:'' }}"
+				 {% elif ordering == '-language' %}class="active desc" href="?order=lang&category={{ category|default:'' }}"
+				 {% else %}href="?order=lang&category={{ category|default:'' }}"{% endif %}>
 				{% trans 'Lang' %}
 				<i class="fa fa-sort fa-lg"></i>
 				<i class="fa fa-sort-asc fa-lg"></i>


### PR DESCRIPTION
fix category filtering not working when ordered by other attributes on review table

## Types of changes
- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
based on 
- https://github.com/pycontw/pycon.tw/blob/daa9f1bfcba8ff46b949f461027138e7a37e664d/src/reviews/views.py#L58
- https://github.com/pycontw/pycon.tw/commit/daa9f1bfcba8ff46b949f461027138e7a37e664d#diff-5bdfe306a76d6b002ae0142965af34400c9baacae4ad6329a82304a1ac15bf4c 
- message https://discord.com/channels/752904426057892052/1198661987761131682/1229294973846032406
Andy found category filtering not working when 1. category is `ALL` and 2. apply a sort on other attributes
This happens because Django template with generate `None` string to a `None` value which caused backend unable to filter the entries properly.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to review page
2. when default ALL is applied
3. click any sort button on any column
4. will show none of proposals (expected all)m.

## Solution
applied `|default''` template tag to sorting `<a href>` tag to make category appears to be empty on URL location, then
backend will not filter it wrong.
