### PR TITLE
fix: add Python dependencies in Dockerfile for ARM-based macOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ FROM node_base as node_deps
 COPY ./yarn.lock yarn.lock
 COPY ./package.json package.json
 
+# ARM-based macOS requires python to rebuild node-sass binary
+RUN apt-get update
+RUN apt-get install -y python3-pip
+
 RUN corepack enable
 RUN yarn install --immutable
 


### PR DESCRIPTION
## Types of changes
- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
Adds Python dependencies to the Dockerfile to address an issue where `node-sass` fails to rebuild its binary on ARM-based macOS systems. This ensures compatibility and successful builds in such environments.

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Clone the repository on an ARM-based macOS system.
2. Build the Docker image using `make run_dev` command.

## Expected behavior
The Docker image should build successfully on ARM-based macOS systems, and the `node-sass` binary should be rebuilt without errors.

## Related Issue
#1206 
