### PR TITLE
fix(ci): update CI workflow to use Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   ci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     services:
       postgres:


### PR DESCRIPTION
## Types of changes
- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
This PR updates the CI configuration to use `ubuntu-24.04` as the runner environment, replacing the deprecated `ubuntu-20.04`. The Ubuntu 20.04 LTS runner was officially removed on 2025-04-15. For more details, refer to [GitHub Actions Runner Images Issue #11101](https://github.com/actions/runner-images/issues/11101).

## Steps to Test This Pull Request
Steps to reproduce the behavior:

1. Open the GitHub Actions workflow file.
2. Verify that the runs-on field is set to ubuntu-24.04.
3. Trigger the workflow by pushing a commit or opening a pull request.

## Expected behavior
The CI pipeline should execute successfully using the `ubuntu-24.04` runner environment.
