### PR TITLE
feat : show second AI review

### DIFF
--- a/src/locale/en_US/LC_MESSAGES/django.po
+++ b/src/locale/en_US/LC_MESSAGES/django.po
@@ -1829,7 +1829,7 @@ msgstr "View AI Summary and Comments"
 
 #: templates/default/dashboard_base.html:57
 msgid "View AI Summary and Comments"
-msgstr "AI Summary and Comments"
+msgstr "View AI Summary and Comments"
 
 #: templates/default/dashboard_base.html:64
 #: templates/default/dashboard_base.html:71
@@ -1847,7 +1847,7 @@ msgstr "Comments"
 
 #: templates/default/dashboard_base.html:89
 msgid "Difference"
-msgstr "Diff"
+msgstr "Difference"
 
 #: templates/default/proposals/_proposal_create.html:14
 msgid "Create Proposal"
@@ -5470,33 +5470,3 @@ msgstr ""
 #: users/views.py:131
 msgid "Password reset successful. You can now login."
 msgstr "Password reset successful. You can now login."
-
-#~ msgid "AI Review"
-#~ msgstr "Review"
-
-#~ msgid "View AI Review"
-#~ msgstr "View AI Review"
-
-#~ msgid "AI-Generated Summary"
-#~ msgstr "AI-generated summary"
-
-#~ msgid "Translated Summary"
-#~ msgstr "translated summary"
-
-#~ msgid "AI-Generated Comments"
-#~ msgstr "AI-generated comment"
-
-#~ msgid "Translated Comments"
-#~ msgstr "translated comment"
-
-#~ msgid "HTML"
-#~ msgstr "HTML"
-
-#~ msgid "Keynote"
-#~ msgstr "Keynote"
-
-#~ msgid "EN Slides"
-#~ msgstr "EN Slides"
-
-#~ msgid "R1, R2, R3"
-#~ msgstr "R1, R2, R3"

--- a/src/locale/en_US/LC_MESSAGES/django.po
+++ b/src/locale/en_US/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PyCon TW\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-13 20:59+0800\n"
+"POT-Creation-Date: 2025-05-15 21:24+0800\n"
 "PO-Revision-Date: 2022-07-11 02:23+0800\n"
 "Last-Translator: Tom Chen <ctchen@gmail.com>\n"
 "Language-Team: English (United States) (http://www.transifex.com/pycon-"
@@ -1796,12 +1796,12 @@ msgstr ""
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: templates/default/dashboard_base.html:16
+#: templates/default/dashboard_base.html:14
 #, python-format
 msgid "Hi %(name)s, welcome!"
 msgstr "Hi %(name)s, welcome!"
 
-#: templates/default/dashboard_base.html:22
+#: templates/default/dashboard_base.html:20
 msgid ""
 "Please verify your account by clicking the link in the mail we sent to your "
 "email inbox."
@@ -1809,56 +1809,45 @@ msgstr ""
 "Please verify your account by clicking the link in the mail we sent to your "
 "email inbox."
 
-#: templates/default/dashboard_base.html:25
+#: templates/default/dashboard_base.html:23
 msgid "Did not get the verification mail?"
 msgstr "Did not get the verification mail?"
 
-#: templates/default/dashboard_base.html:26
+#: templates/default/dashboard_base.html:24
 msgid "Request a new one."
 msgstr "Request a new one."
 
-#: templates/default/dashboard_base.html:32
+#: templates/default/dashboard_base.html:30
 msgid ""
 "You need to complete your speaker profile first before submitting a proposal."
 msgstr ""
 "You need to complete your speaker profile first before submitting a proposal."
 
-#: templates/default/dashboard_base.html:57
+#: templates/default/dashboard_base.html:53
 msgid "View AI Summary and Comments "
-msgstr ""
+msgstr "View AI Summary and Comments"
 
-#: templates/default/dashboard_base.html:63
-msgid " AI Summary and Comments "
-msgstr ""
+#: templates/default/dashboard_base.html:57
+msgid "View AI Summary and Comments"
+msgstr "AI Summary and Comments"
 
-#: templates/default/dashboard_base.html:72
+#: templates/default/dashboard_base.html:64
+#: templates/default/dashboard_base.html:71
 msgid "AI Recommendation Category"
-msgstr ""
-
-#: templates/default/dashboard_base.html:81
-msgid "Summary"
-msgstr ""
+msgstr "AI Recommendation Category"
 
 #: templates/default/dashboard_base.html:82
+msgid "Summary"
+msgstr "Summary"
+
+#: templates/default/dashboard_base.html:85
 #: templates/default/reviews/_includes/previous_review_table.html:9
 msgid "Comments"
 msgstr "Comments"
 
-#: templates/default/dashboard_base.html:90
-msgid "AI-Generated Summary"
-msgstr "AI-generated summary"
-
-#: templates/default/dashboard_base.html:95
-msgid "Translated Summary"
-msgstr "translated summary"
-
-#: templates/default/dashboard_base.html:105
-msgid "AI-Generated Comments"
-msgstr "AI-generated comment"
-
-#: templates/default/dashboard_base.html:110
-msgid "Translated Comments"
-msgstr "translated comment"
+#: templates/default/dashboard_base.html:89
+msgid "Difference"
+msgstr "Diff"
 
 #: templates/default/proposals/_proposal_create.html:14
 msgid "Create Proposal"
@@ -5481,6 +5470,24 @@ msgstr ""
 #: users/views.py:131
 msgid "Password reset successful. You can now login."
 msgstr "Password reset successful. You can now login."
+
+#~ msgid "AI Review"
+#~ msgstr "Review"
+
+#~ msgid "View AI Review"
+#~ msgstr "View AI Review"
+
+#~ msgid "AI-Generated Summary"
+#~ msgstr "AI-generated summary"
+
+#~ msgid "Translated Summary"
+#~ msgstr "translated summary"
+
+#~ msgid "AI-Generated Comments"
+#~ msgstr "AI-generated comment"
+
+#~ msgid "Translated Comments"
+#~ msgstr "translated comment"
 
 #~ msgid "HTML"
 #~ msgstr "HTML"

--- a/src/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/src/locale/zh_Hant/LC_MESSAGES/django.po
@@ -1771,7 +1771,7 @@ msgstr "檢視 AI 摘要評論"
 
 #: templates/default/dashboard_base.html:57
 msgid "View AI Summary and Comments"
-msgstr "AI 摘要評論"
+msgstr "查看 AI 摘要評論"
 
 #: templates/default/dashboard_base.html:64
 #: templates/default/dashboard_base.html:71
@@ -5338,33 +5338,3 @@ msgstr ""
 #: users/views.py:131
 msgid "Password reset successful. You can now login."
 msgstr "密碼重設成功。您現在即可登入。"
-
-#~ msgid "AI Review"
-#~ msgstr "審查"
-
-#~ msgid " AI Summary and Comments "
-#~ msgstr " AI 摘要評論"
-
-#~ msgid "AI-Generated Summary"
-#~ msgstr "AI 生成的摘要"
-
-#~ msgid "Translated Summary"
-#~ msgstr "翻譯後的摘要"
-
-#~ msgid "AI-Generated Comments"
-#~ msgstr "AI 生成的評論"
-
-#~ msgid "Translated Comments"
-#~ msgstr "翻譯後的評論"
-
-#~ msgid "HTML"
-#~ msgstr "HTML"
-
-#~ msgid "Keynote"
-#~ msgstr "基調演講"
-
-#~ msgid "EN Slides"
-#~ msgstr "英文投影片"
-
-#~ msgid "R1, R2, R3"
-#~ msgstr "R1、R2、R3"

--- a/src/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/src/locale/zh_Hant/LC_MESSAGES/django.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PyCon TW\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-13 20:59+0800\n"
+"POT-Creation-Date: 2025-05-15 21:24+0800\n"
 "PO-Revision-Date: 2022-07-11 02:25+0800\n"
 "Last-Translator: Tom Chen <ctchen@gmail.com>\n"
 "Language-Team: Chinese Traditional (http://www.transifex.com/pycon-taiwan/"
@@ -1741,66 +1741,55 @@ msgstr ""
 msgid "Dashboard"
 msgstr "控制面板"
 
-#: templates/default/dashboard_base.html:16
+#: templates/default/dashboard_base.html:14
 #, python-format
 msgid "Hi %(name)s, welcome!"
 msgstr "嗨 %(name)s，歡迎！"
 
-#: templates/default/dashboard_base.html:22
+#: templates/default/dashboard_base.html:20
 msgid ""
 "Please verify your account by clicking the link in the mail we sent to your "
 "email inbox."
 msgstr "我們已寄帳號認證信至您的信箱，請點擊信中的連結完成認證。"
 
-#: templates/default/dashboard_base.html:25
+#: templates/default/dashboard_base.html:23
 msgid "Did not get the verification mail?"
 msgstr "沒有收到認證信嗎？"
 
-#: templates/default/dashboard_base.html:26
+#: templates/default/dashboard_base.html:24
 msgid "Request a new one."
 msgstr "重新寄送一封。"
 
-#: templates/default/dashboard_base.html:32
+#: templates/default/dashboard_base.html:30
 msgid ""
 "You need to complete your speaker profile first before submitting a proposal."
 msgstr "在投稿前，您必須先完成填寫講者資訊。"
 
-#: templates/default/dashboard_base.html:57
+#: templates/default/dashboard_base.html:53
 msgid "View AI Summary and Comments "
 msgstr "檢視 AI 摘要評論"
 
-#: templates/default/dashboard_base.html:63
-msgid " AI Summary and Comments "
-msgstr " AI 摘要評論"
+#: templates/default/dashboard_base.html:57
+msgid "View AI Summary and Comments"
+msgstr "AI 摘要評論"
 
-#: templates/default/dashboard_base.html:72
+#: templates/default/dashboard_base.html:64
+#: templates/default/dashboard_base.html:71
 msgid "AI Recommendation Category"
 msgstr "AI 建議分類"
 
-#: templates/default/dashboard_base.html:81
-msgid "Summary"
-msgstr ""
-
 #: templates/default/dashboard_base.html:82
+msgid "Summary"
+msgstr "摘要"
+
+#: templates/default/dashboard_base.html:85
 #: templates/default/reviews/_includes/previous_review_table.html:9
 msgid "Comments"
 msgstr "評論"
 
-#: templates/default/dashboard_base.html:90
-msgid "AI-Generated Summary"
-msgstr "AI 生成的摘要"
-
-#: templates/default/dashboard_base.html:95
-msgid "Translated Summary"
-msgstr "翻譯後的摘要"
-
-#: templates/default/dashboard_base.html:105
-msgid "AI-Generated Comments"
-msgstr "AI 生成的評論"
-
-#: templates/default/dashboard_base.html:110
-msgid "Translated Comments"
-msgstr "翻譯後的評論"
+#: templates/default/dashboard_base.html:89
+msgid "Difference"
+msgstr "差異"
 
 #: templates/default/proposals/_proposal_create.html:14
 msgid "Create Proposal"
@@ -5349,6 +5338,24 @@ msgstr ""
 #: users/views.py:131
 msgid "Password reset successful. You can now login."
 msgstr "密碼重設成功。您現在即可登入。"
+
+#~ msgid "AI Review"
+#~ msgstr "審查"
+
+#~ msgid " AI Summary and Comments "
+#~ msgstr " AI 摘要評論"
+
+#~ msgid "AI-Generated Summary"
+#~ msgstr "AI 生成的摘要"
+
+#~ msgid "Translated Summary"
+#~ msgstr "翻譯後的摘要"
+
+#~ msgid "AI-Generated Comments"
+#~ msgstr "AI 生成的評論"
+
+#~ msgid "Translated Comments"
+#~ msgstr "翻譯後的評論"
 
 #~ msgid "HTML"
 #~ msgstr "HTML"

--- a/src/reviews/views.py
+++ b/src/reviews/views.py
@@ -273,6 +273,9 @@ class ReviewEditView(ReviewableMixin, PermissionRequiredMixin, UpdateView):
             proposal=self.proposal, filter_user=self.request.user
         ).order_by("stage")
         if self.proposal.accepted is None and self.object:
+            # If this proposal does not have verdict, this page will have a
+            # review form. Exclude the current user's current review so that
+            # it does not show up twice (once in the table, once in form).
             my_reviews = my_reviews.exclude(pk=self.object.pk)
 
         # 3. LLMReview 階段 1

--- a/src/reviews/views.py
+++ b/src/reviews/views.py
@@ -26,51 +26,51 @@ class ReviewableMixin:
 
 
 class TalkProposalListView(ReviewableMixin, PermissionRequiredMixin, ListView):
-
     model = TalkProposal
     permission_required = REVIEW_REQUIRED_PERMISSIONS
-    template_name = 'reviews/talk_proposal_list.html'
+    template_name = "reviews/talk_proposal_list.html"
     vote_keys = {
-        Review.Vote.PLUS_ONE: 'strong_accept',
-        Review.Vote.PLUS_ZERO: 'weak_accept',
-        Review.Vote.MINUS_ZERO: 'weak_reject',
-        Review.Vote.MINUS_ONE: 'strong_reject',
+        Review.Vote.PLUS_ONE: "strong_accept",
+        Review.Vote.PLUS_ZERO: "weak_accept",
+        Review.Vote.MINUS_ZERO: "weak_reject",
+        Review.Vote.MINUS_ONE: "strong_reject",
     }
     order_keys = {
-        'title': 'title',
-        'count': 'review__count',
-        'category': 'category',
-        'level': 'python_level',
-        'lang': 'language',
-        '-title': '-title',
-        '-count': '-review__count',
-        '-category': '-category',
-        '-level': '-python_level',
-        '-lang': '-language',
+        "title": "title",
+        "count": "review__count",
+        "category": "category",
+        "level": "python_level",
+        "lang": "language",
+        "-title": "-title",
+        "-count": "-review__count",
+        "-category": "-category",
+        "-level": "-python_level",
+        "-lang": "-language",
     }
     paginate_by = 150
 
     def get_ordering(self):
         params = self.request.GET
-        order_key = self.order_keys.get(params.get('order', '').lower())
-        return order_key or '?'
+        order_key = self.order_keys.get(params.get("order", "").lower())
+        return order_key or "?"
 
     def get_category(self):
         params = self.request.GET
-        return params.get('category')
+        return params.get("category")
 
     def get_queryset(self):
         user = self.request.user
         qs = (
-            super().get_queryset()
+            super()
+            .get_queryset()
             .filter_reviewable(user)
             .exclude(accepted__isnull=False)
             .exclude(review__reviewer=user)
-            .annotate(Count('review'))
+            .annotate(Count("review"))
         )
 
         ordering = self.get_ordering()
-        if ordering == '?':
+        if ordering == "?":
             # We don't use order_by('?') because it is crazy slow, and instead
             # resolve the queryset to a list, and shuffle it normally. This is
             # OK since we will iterate through it in the template anyway.
@@ -79,10 +79,10 @@ class TalkProposalListView(ReviewableMixin, PermissionRequiredMixin, ListView):
             # ordering, and add an appropriate DISTINCT on the query. This
             # is caused by a Django logic error regarding how ORDER BY
             # contributes to GROUP BY.
-            proposal_list = list(qs.order_by('pk'))
+            proposal_list = list(qs.order_by("pk"))
             random.shuffle(proposal_list)
             qs = SequenceQuerySet(proposal_list)
-            ordering = '?'
+            ordering = "?"
         else:
             qs = qs.order_by(ordering)
         self.ordering = ordering
@@ -98,18 +98,14 @@ class TalkProposalListView(ReviewableMixin, PermissionRequiredMixin, ListView):
                 count += 1
             if proposal.category not in categories:
                 categories.add(proposal.category)
-        return {
-            "category_options": categories,
-            "filtered_count": count if count else len(context["object_list"])
-        }
+        return {"category_options": categories, "filtered_count": count if count else len(context["object_list"])}
 
     def get_context_data(self, **kwargs):
         review_stage = self.reviews_state.reviews_stage
         verdicted_proposals = (
-            TalkProposal.objects
-            .filter_reviewable(self.request.user)
+            TalkProposal.objects.filter_reviewable(self.request.user)
             .filter(accepted__isnull=False)
-            .annotate(Count('review'))
+            .annotate(Count("review"))
         )
 
         stage_1_vote_count_pairs = (
@@ -118,8 +114,8 @@ class TalkProposalListView(ReviewableMixin, PermissionRequiredMixin, ListView):
             # the model. The default ordering contributes to GROUP BY, and
             # breaks the COUNT aggregation.
             .order_by()
-            .values_list('vote')
-            .annotate(count=Count('vote'))
+            .values_list("vote")
+            .annotate(count=Count("vote"))
         )
         stage_2_vote_count_pairs = (
             self.get_stage_2_reviews()
@@ -127,8 +123,8 @@ class TalkProposalListView(ReviewableMixin, PermissionRequiredMixin, ListView):
             # the model. The default ordering contributes to GROUP BY, and
             # breaks the COUNT aggregation.
             .order_by()
-            .values_list('vote')
-            .annotate(count=Count('vote'))
+            .values_list("vote")
+            .annotate(count=Count("vote"))
         )
         vote_count_pairs = stage_1_vote_count_pairs.union(stage_2_vote_count_pairs, all=True)
         vote_mapping = collections.defaultdict(int)
@@ -136,47 +132,36 @@ class TalkProposalListView(ReviewableMixin, PermissionRequiredMixin, ListView):
             vote_mapping[self.vote_keys[k]] += v
 
         context = super().get_context_data(**kwargs)
-        context.update({
-            'proposals_with_verdict': verdicted_proposals,
-            'stage_1_reviews': self.get_stage_1_reviews(),
-            'stage_2_reviews': self.get_stage_2_reviews(),
-            'total_reviewed_amount': len(self.get_stage_1_reviews()) + len(self.get_stage_2_reviews()),
-            'review_stage': review_stage,
-            'review_stage_desc_tpl': (
-                'reviews/_includes/review_stage_%s_desc.html'
-                % review_stage
-            ),
-            'vote': vote_mapping,
-            'ordering': self.ordering,
-            'category': self.category,
-            'query_string': self.request.GET.urlencode(),
-            **self.reviews_state._asdict(),
-            **self.get_category_metrics(context),
-        })
+        context.update(
+            {
+                "proposals_with_verdict": verdicted_proposals,
+                "stage_1_reviews": self.get_stage_1_reviews(),
+                "stage_2_reviews": self.get_stage_2_reviews(),
+                "total_reviewed_amount": len(self.get_stage_1_reviews()) + len(self.get_stage_2_reviews()),
+                "review_stage": review_stage,
+                "review_stage_desc_tpl": ("reviews/_includes/review_stage_%s_desc.html" % review_stage),
+                "vote": vote_mapping,
+                "ordering": self.ordering,
+                "category": self.category,
+                "query_string": self.request.GET.urlencode(),
+                **self.reviews_state._asdict(),
+                **self.get_category_metrics(context),
+            }
+        )
         return context
 
     def get_stage_1_reviews(self):
         review_stage = self.reviews_state.reviews_stage
         if review_stage == 1:
             stage_1_reviews = (
-                Review.objects
-                .select_related('proposal')
-                .filter_reviewable(self.request.user)
-                .exclude(stage=2)
+                Review.objects.select_related("proposal").filter_reviewable(self.request.user).exclude(stage=2)
             )
         elif review_stage == 2:
-            proposals = (
-                TalkProposal.objects.filter(
-                    review__stage=1,
-                    review__reviewer=self.request.user
-                ) & TalkProposal.objects.filter(
-                    review__stage=2,
-                    review__reviewer=self.request.user
-                )
-            )
+            proposals = TalkProposal.objects.filter(
+                review__stage=1, review__reviewer=self.request.user
+            ) & TalkProposal.objects.filter(review__stage=2, review__reviewer=self.request.user)
             stage_1_reviews = (
-                Review.objects
-                .select_related('proposal')
+                Review.objects.select_related("proposal")
                 .filter_reviewable(self.request.user)
                 .filter(proposal__accepted__isnull=True)
                 .exclude(proposal__in=proposals, stage=1)
@@ -190,8 +175,7 @@ class TalkProposalListView(ReviewableMixin, PermissionRequiredMixin, ListView):
             return Review.objects.none()
         elif review_stage == 2:
             stage_2_reviews = (
-                Review.objects
-                .select_related('proposal')
+                Review.objects.select_related("proposal")
                 .filter_reviewable(self.request.user)
                 .filter(proposal__accepted__isnull=True)
                 .exclude(stage=1)
@@ -200,19 +184,16 @@ class TalkProposalListView(ReviewableMixin, PermissionRequiredMixin, ListView):
 
 
 class ReviewEditView(ReviewableMixin, PermissionRequiredMixin, UpdateView):
-
     form_class = ReviewForm
     permission_required = REVIEW_REQUIRED_PERMISSIONS
-    template_name = 'reviews/review_form.html'
+    template_name = "reviews/review_form.html"
     proposal_model = TalkProposal
     snapshot_model = TalkProposalSnapshot
 
     def get_proposal(self):
         try:
-            proposal = (
-                self.proposal_model.objects
-                .filter_reviewable(self.request.user)
-                .get(pk=self.kwargs['proposal_pk'])
+            proposal = self.proposal_model.objects.filter_reviewable(self.request.user).get(
+                pk=self.kwargs["proposal_pk"]
             )
         except self.proposal_model.DoesNotExist as err:
             raise Http404 from err
@@ -220,14 +201,9 @@ class ReviewEditView(ReviewableMixin, PermissionRequiredMixin, UpdateView):
 
     def get_snapshot(self, proposal):
         try:
-            snapshot = (
-                self.snapshot_model.objects
-                .filter(
-                    proposal=proposal,
-                    stage__lt=self.reviews_state.reviews_stage
-                )
-                .latest('dumped_at')
-            )
+            snapshot = self.snapshot_model.objects.filter(
+                proposal=proposal, stage__lt=self.reviews_state.reviews_stage
+            ).latest("dumped_at")
         except self.snapshot_model.DoesNotExist:
             return None
         try:
@@ -259,11 +235,13 @@ class ReviewEditView(ReviewableMixin, PermissionRequiredMixin, UpdateView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        kwargs.update({
-            'request': self.request,
-            'proposal': self.proposal,
-        })
-        if kwargs.get('instance') is not None or kwargs.get('initial'):
+        kwargs.update(
+            {
+                "request": self.request,
+                "proposal": self.proposal,
+            }
+        )
+        if kwargs.get("instance") is not None or kwargs.get("initial"):
             return kwargs
         try:
             review = Review.objects.get(
@@ -273,11 +251,11 @@ class ReviewEditView(ReviewableMixin, PermissionRequiredMixin, UpdateView):
             )
         except Review.DoesNotExist:
             return kwargs
-        kwargs['initial'] = {
-            'vote': review.vote,
-            'comment': review.comment,
-            'note': review.note,
-            'discloses_comment': review.discloses_comment,
+        kwargs["initial"] = {
+            "vote": review.vote,
+            "comment": review.comment,
+            "note": review.note,
+            "discloses_comment": review.discloses_comment,
         }
         return kwargs
 
@@ -285,96 +263,81 @@ class ReviewEditView(ReviewableMixin, PermissionRequiredMixin, UpdateView):
         review_stage = self.reviews_state.reviews_stage
 
         # 1. 其他人的 review
-        other_review_iter = (
-            Review.objects
-                  .filter_current_reviews(
-                      proposal=self.proposal,
-                      exclude_user=self.request.user
-                  )
-                  .iter_reviewer_latest_reviews()
-        )
-        other_reviews = sorted(
-            other_review_iter,
-            key=lambda r: Review.VOTE_ORDER[r.vote]
-        )
+        other_review_iter = Review.objects.filter_current_reviews(
+            proposal=self.proposal, exclude_user=self.request.user
+        ).iter_reviewer_latest_reviews()
+        other_reviews = sorted(other_review_iter, key=lambda r: Review.VOTE_ORDER[r.vote])
 
         # 2. 我自己的 review
-        my_reviews = (
-            Review.objects
-                  .filter_current_reviews(
-                      proposal=self.proposal,
-                      filter_user=self.request.user
-                  )
-                  .order_by('stage')
-        )
+        my_reviews = Review.objects.filter_current_reviews(
+            proposal=self.proposal, filter_user=self.request.user
+        ).order_by("stage")
         if self.proposal.accepted is None and self.object:
             my_reviews = my_reviews.exclude(pk=self.object.pk)
 
         # 3. LLMReview 階段 1
         summary_text = comment_text = translated_summary = translated_comment = ""
         categories = []
-        llm1 = (
-            LLMReview.objects
-                     .filter(proposal=self.proposal, stage=LLMReview.STAGE_1)
-                     .first()
-        )
-        if llm1:
-            summary_text = llm1.summary
-            comment_text = llm1.comment
-            translated_summary = llm1.translated_summary
-            translated_comment = llm1.translated_comment
-            categories = llm1.categories
+        llm_stage_1 = LLMReview.objects.filter(proposal=self.proposal, stage=LLMReview.STAGE_1).first()
+        if llm_stage_1:
+            summary_text = llm_stage_1.summary
+            comment_text = llm_stage_1.comment
+            translated_summary = llm_stage_1.translated_summary
+            translated_comment = llm_stage_1.translated_comment
+            categories = llm_stage_1.categories
         else:
             summary_text = "No AI summary available for this proposal."
             comment_text = "No AI comments available for this proposal."
 
         # 4. LLMReview 階段 2（包含翻譯欄位）
-        llm2 = (
-            LLMReview.objects
-                     .filter(proposal=self.proposal, stage=LLMReview.STAGE_2)
-                     .first()
-        )
-        if llm2:
-            kwargs.update({
-                'stage_2_summary':               llm2.summary,
-                'stage_2_translated_summary':    llm2.translated_summary,
-                'stage_2_comment':               llm2.comment,
-                'stage_2_translated_comment':    llm2.translated_comment,
-                'stage_2_categories':            llm2.categories,
-                'stage_2_stage_diff':            llm2.stage_diff,
-                'stage_2_translated_stage_diff': llm2.translated_stage_diff,
-            })
+        llm_stage_2 = LLMReview.objects.filter(proposal=self.proposal, stage=LLMReview.STAGE_2).first()
+        if llm_stage_2:
+            kwargs.update(
+                {
+                    "stage_2_summary": llm_stage_2.summary,
+                    "stage_2_translated_summary": llm_stage_2.translated_summary,
+                    "stage_2_comment": llm_stage_2.comment,
+                    "stage_2_translated_comment": llm_stage_2.translated_comment,
+                    "stage_2_categories": llm_stage_2.categories,
+                    "stage_2_stage_diff": llm_stage_2.stage_diff,
+                    "stage_2_translated_stage_diff": llm_stage_2.translated_stage_diff,
+                }
+            )
         else:
-            kwargs.update({
-                'stage_2_summary':               '',
-                'stage_2_translated_summary':    '',
-                'stage_2_comment':               '',
-                'stage_2_translated_comment':    '',
-                'stage_2_categories':            [],
-                'stage_2_stage_diff':            '',
-                'stage_2_translated_stage_diff': '',
-            })
+            kwargs.update(
+                {
+                    "stage_2_summary": "",
+                    "stage_2_translated_summary": "",
+                    "stage_2_comment": "",
+                    "stage_2_translated_comment": "",
+                    "stage_2_categories": [],
+                    "stage_2_stage_diff": "",
+                    "stage_2_translated_stage_diff": "",
+                }
+            )
 
         # 5. 最後把共用的 context 都放進去
-        kwargs.update({
-            'proposal':           self.proposal,
-            'snapshot':           self.get_snapshot(self.proposal),
-            'other_reviews':      other_reviews,
-            'my_reviews':         my_reviews,
-            'review_stage':       review_stage,
-            'summary_text':       summary_text,
-            'comment_text':       comment_text,
-            'translated_summary': translated_summary,
-            'translated_comment': translated_comment,
-            'categories':         categories,
-            **self.reviews_state._asdict(),
-        })
+        kwargs.update(
+            {
+                "proposal": self.proposal,
+                "snapshot": self.get_snapshot(self.proposal),
+                "other_reviews": other_reviews,
+                "my_reviews": my_reviews,
+                "review_stage": review_stage,
+                "summary_text": summary_text,
+                "comment_text": comment_text,
+                "translated_summary": translated_summary,
+                "translated_comment": translated_comment,
+                "categories": categories,
+                **self.reviews_state._asdict(),
+            }
+        )
 
         return super().get_context_data(**kwargs)
 
     def get_success_url(self):
         query_string = self.request.GET.urlencode()
-        url = reverse('review_proposal_list')
+        url = reverse("review_proposal_list")
         if query_string:
-            return url + '?' + query_string
+            return url + "?" + query_string
         return url

--- a/src/templates/default/dashboard_base.html
+++ b/src/templates/default/dashboard_base.html
@@ -4,10 +4,8 @@
 {% load pycontw_tools %}
 {% load static %}
 
-{% block title %}{% trans 'Dashboard' %}{% endblock title %}
-
+{% block title %}{% trans 'Dashboard' %}{% endblock %}
 {% block body-class %}dashboard{% endblock %}
-
 {% block nav %}{% include '_includes/nav/dashboard_nav.html' %}{% endblock %}
 
 {% block content %}
@@ -32,7 +30,6 @@
       <p>{% trans 'You need to complete your speaker profile first before submitting a proposal.' %}</p>
     </div>
   {% endif %}
-
   {% for message in messages %}
     <div class="alert {{ message|message_bootstrap_class_str }} clearfix" role="alert">
       <p>{{ message }}</p>
@@ -42,77 +39,103 @@
 
 <div class="row main-container">
   <div class="col-md-2 sidebar">
-    {% block dashboard_tablist %}{% endblock dashboard_tablist %}
+    {% block dashboard_tablist %}{% endblock %}
   </div>
   <div class="col-md-10 main">
     {% block main-content %}{% endblock %}
   </div>
 </div>
 
-<!-- Summary display box (right-bottom corner) -->
-{% if summary_text or comment_text %}
+{# AI Review Panel #}
+{% if review_stage == 1 or review_stage == 2 %}
   <div class="support-box-container">
-    <!-- 小長方形觸發按鈕 -->
     <div class="support-box-trigger" id="supportBoxTrigger">
-      <span>{% trans "View AI Summary and Comments " %}</span>
+      <span>{% trans 'View AI Summary and Comments ' %}</span>
     </div>
-
-    <!-- 展開後的摘要面板 -->
     <div class="support-box-panel" id="supportBoxPanel">
       <div class="support-box-header">
-        <div class="support-box-title">{% trans " AI Summary and Comments " %}</div>
-        <button class="support-box-close" id="supportBoxClose">
-          <span></span>
-          <span></span>
-        </button>
+        <div class="support-box-title">{% trans 'View AI Summary and Comments' %}</div>
+        <button class="support-box-close" id="supportBoxClose"><span></span><span></span></button>
       </div>
       <div class="support-box-content">
-        {% if category %}
-          <div class="category-display" style="margin-bottom: 12px;">
-            <strong>{% trans "AI Recommendation Category" %}:</strong> {{ category }}
+        {# Recommendation Categories #}
+        {% if review_stage == 1 and categories %}
+          <div class="category-display mb-3">
+            <strong>{% trans 'AI Recommendation Category' %}:</strong>
+            <ul>
+              {% for cat in categories %}<li>{{ cat }}</li>{% endfor %}
+            </ul>
           </div>
-          <hr style="margin-bottom: 12px;">
+        {% elif review_stage == 2 and stage_2_categories %}
+          <div class="category-display mb-3">
+            <strong>{% trans 'AI Recommendation Category' %}:</strong>
+            <ul>
+              {% for cat in stage_2_categories %}<li>{{ cat }}</li>{% endfor %}
+            </ul>
+          </div>
         {% endif %}
 
         {% get_current_language as LANGUAGE_CODE %}
-
-        <!-- 使用標籤頁來區分摘要和評論 -->
+        {# Tabs for Summary, Comments, (Difference) #}
         <ul class="nav nav-pills mb-3" role="tablist">
-          <li class="active"><a href="#summary-tab" role="tab" data-toggle="tab">{% trans "Summary" %}</a></li>
-          <li><a href="#comment-tab" role="tab" data-toggle="tab">{% trans "Comments" %}</a></li>
+          <li class="nav-item">
+            <a class="nav-link active" data-toggle="pill" href="#summary" role="tab">{% trans 'Summary' %}</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" data-toggle="pill" href="#comments" role="tab">{% trans 'Comments' %}</a>
+          </li>
+          {% if review_stage == 2 %}
+            <li class="nav-item">
+              <a class="nav-link" data-toggle="pill" href="#diff" role="tab">{% trans 'Difference' %}</a>
+            </li>
+          {% endif %}
         </ul>
 
         <div class="tab-content">
-          <!-- 摘要標籤頁 -->
-          <div class="tab-pane active" id="summary-tab">
-            {% if LANGUAGE_CODE == "zh-hant" or LANGUAGE_CODE == "zh-tw" %}
-              {% if summary_text %}
-                <!-- <h4>{% trans "AI-Generated Summary" %}</h4> -->
-                <p >{{ summary_text|linebreaksbr }}</p>
+          {# Summary Pane #}
+          <div class="tab-pane active" id="summary" role="tabpanel">
+            {% if LANGUAGE_CODE == 'zh-hant' or LANGUAGE_CODE == 'zh-tw' %}
+              {% if review_stage == 1 %}
+                <p>{{ summary_text  |linebreaksbr }}</p>
+              {% else %}
+                <p>{{  stage_2_summary|linebreaksbr }}</p>
               {% endif %}
             {% else %}
-              {% if translated_summary %}
-                <!-- <h4>{% trans "Translated Summary" %}</h4> -->
-                <p >{{ translated_summary|linebreaksbr }}</p>
+              {% if review_stage == 1 %}
+                <p>{{ translated_summary|linebreaksbr }}</p>
+              {% else %}
+                <p>{{ stage_2_translated_summary|linebreaksbr }}</p>
               {% endif %}
             {% endif %}
           </div>
-
-          <!-- 評論標籤頁 -->
-          <div class="tab-pane" id="comment-tab">
-            {% if LANGUAGE_CODE == "zh-hant" or LANGUAGE_CODE == "zh-tw" %}
-              {% if comment_text %}
-                <!-- <h4>{% trans "AI-Generated Comments" %}</h4> -->
-                <p >{{ comment_text|linebreaksbr }}</p>
+          {# Comments Pane #}
+          <div class="tab-pane fade" id="comments" role="tabpanel">
+            {% if LANGUAGE_CODE == 'zh-hant' or LANGUAGE_CODE == 'zh-tw' %}
+              {% if review_stage == 1 %}
+                <p>{{ comment_text |linebreaksbr }}</p>
+              {% else %}
+                <p>{{ stage_2_comment |linebreaksbr }}</p>
               {% endif %}
             {% else %}
-              {% if translated_comment %}
-                <!-- <h4>{% trans "Translated Comments" %}</h4> -->
-                <p >{{ translated_comment|linebreaksbr }}</p>
+              {% if review_stage == 1 %}
+                <p>{{ translated_comment |linebreaksbr }}</p>
+              {% else %}
+                <p>{{  stage_2_translated_comment |linebreaksbr }}</p>
               {% endif %}
             {% endif %}
           </div>
+          {# Difference Pane (only Stage 2) #}
+          {% if review_stage == 2 %}
+            <div class="tab-pane fade" id="diff" role="tabpanel">
+              {% if LANGUAGE_CODE == 'zh-hant' or LANGUAGE_CODE == 'zh-tw' %}
+                <p>{{ stage_2_stage_diff  }}</p>
+              {% else %}
+                <p>{{ stage_2_translated_stage_diff }}</p>
+              {% endif %}
+            </div>
+          {% endif %}
         </div>
+
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Types of changes
**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies


- [x ] **New feature**


## Description
新增「第二次審稿」區塊標題
顯示 Stage 2 的 摘要（summary）
顯示 Stage 2 的 評論（comment）
顯示 Stage 1 與 Stage 2 之間的 差異（diff）
僅當提案已有第二筆 LLMReview 記錄時才渲染此區塊，若僅有一次審稿則不顯示。



## Steps to Test This Pull Request
1. 進入審稿的頁面
2. 點選其中一個稿件
3.驗證「第二次審稿」區塊是否出現，並確認其中包含：
摘要：對應第二次審稿的 summary 欄位
評論：對應第二次審稿的 comment 欄位
Diff：呈現 Stage 1 與 Stage 2 之間的變更

## Expected behavior
如圖所示，並對應到後台第二次 AI 審稿的內容
![image](https://github.com/user-attachments/assets/503af032-6fe1-47e8-bae1-5bf9081822f1)


## Related Issue
#1238 
#1230 



